### PR TITLE
FIX | Initial Performance Level

### DIFF
--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/base/PerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/base/PerformanceManager.kt
@@ -9,6 +9,9 @@ import com.blinkit.droiddex.utils.runAsyncPeriodically
 
 internal abstract class PerformanceManager(private val isInDebugMode: Boolean) {
 
+	var performanceLevel = PerformanceLevel.UNKNOWN
+		private set
+
 	private val _performanceLevelLd = MutableLiveData(PerformanceLevel.UNKNOWN)
 	val performanceLevelLd: LiveData<PerformanceLevel>
 		get() = _performanceLevelLd
@@ -20,7 +23,10 @@ internal abstract class PerformanceManager(private val isInDebugMode: Boolean) {
 			try {
 				measurePerformanceLevel().also {
 					val hasPerformanceLevelChanged = performanceLevelLd.value != it
-					if (hasPerformanceLevelChanged) _performanceLevelLd.postValue(it)
+					if (hasPerformanceLevelChanged) {
+						performanceLevel = it
+						_performanceLevelLd.postValue(it)
+					}
 					logger.logPerformanceLevelChange(it, hasPerformanceLevelChanged)
 				}
 			} catch (e: Exception) {

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/base/PerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/base/PerformanceManager.kt
@@ -6,9 +6,11 @@ import com.blinkit.droiddex.constants.PerformanceClass
 import com.blinkit.droiddex.constants.PerformanceLevel
 import com.blinkit.droiddex.utils.Logger
 import com.blinkit.droiddex.utils.runAsyncPeriodically
+import kotlin.concurrent.Volatile
 
 internal abstract class PerformanceManager(private val isInDebugMode: Boolean) {
 
+	@Volatile
 	var performanceLevel = PerformanceLevel.UNKNOWN
 		private set
 

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/factory/PerformanceManagerFactory.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/factory/PerformanceManagerFactory.kt
@@ -20,7 +20,7 @@ internal class PerformanceManagerFactory(private val applicationContext: Context
 	}
 
 	fun getPerformanceLevel(@PerformanceClass performanceClass: Int): PerformanceLevel =
-		getOrPut(performanceClass).performanceLevelLd.value ?: PerformanceLevel.UNKNOWN
+		getOrPut(performanceClass).performanceLevel
 
 	fun getPerformanceLevelLd(@PerformanceClass performanceClass: Int): LiveData<PerformanceLevel> =
 		getOrPut(performanceClass).performanceLevelLd

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ org.gradle.configuration-cache-problems=warn
 # Maven Publishing
 GROUP=com.blinkit.kits
 POM_ARTIFACT_ID=droid-dex
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=Droid Dex
 POM_DESCRIPTION=Classification and Analysis of Android Device Performance


### PR DESCRIPTION
The initial performance level is `UNKNOWN` till  `postValue` of `PerformanceManagerFactory` could not execute the data updating. Maintaining a variable to get the performance level instantly and a live-data to observe.