### PR TITLE
Add THERMAL class and rework CPU and MEMORY tier classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ It is a powerful tool that classifies and analyzes Android device performance ac
 
 | PARAMETER                                                                                                                  | DESCRIPTION                                         |
 |----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| <div align="center">[CPU](./droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt)</div>             | Total RAM, Core Count, CPU Frequency                |
-| <div align="center">[MEMORY](./droid-dex/src/main/kotlin/com/blinkit/droiddex/memory/MemoryPerformanceManager.kt)</div>    | Heap Limit, Heap Remaining, Available RAM           |
+| <div align="center">[CPU](./droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt)</div>             | Core Microarchitecture, CPU Frequency, Media Performance Class, Low-End Hardware Signals |
+| <div align="center">[MEMORY](./droid-dex/src/main/kotlin/com/blinkit/droiddex/memory/MemoryPerformanceManager.kt)</div>    | Total RAM, OEM Memory Class, Runtime Memory Pressure |
 | <div align="center">[NETWORK](./droid-dex/src/main/kotlin/com/blinkit/droiddex/network/NetworkPerformanceManager.kt)</div> | Bandwidth Strength, Download Speed, Signal Strength |
 | <div align="center">[STORAGE](./droid-dex/src/main/kotlin/com/blinkit/droiddex/storage/StoragePerformanceManager.kt)</div> | Available Storage                                   |
 | <div align="center">[BATTERY](./droid-dex/src/main/kotlin/com/blinkit/droiddex/battery/BatteryPerformanceManager.kt)</div> | Percentage Remaining, If Phone is Charging or Not   |
+| <div align="center">[THERMAL](./droid-dex/src/main/kotlin/com/blinkit/droiddex/thermal/ThermalPerformanceManager.kt)</div> | Thermal Throttling Status, Thermal Headroom Forecast |
 
 into various [levels](./droid-dex/src/main/kotlin/com/blinkit/droiddex/constants/PerformanceLevel.kt): **EXCELLENT**,
-**HIGH**, **AVERAGE**, **LOW**
+**HIGH**, **AVERAGE**, **LOW**, plus **UNKNOWN** for a parameter this device cannot measure (excluded
+from aggregation)
 
 Droid Dex enhances your Android application's performance and elevates user experience by addressing key performance
 challenges such as Janky scrolling, Out of Memory (OOM) errors, High battery consumption, and Application Not
@@ -56,6 +58,21 @@ More Info: https://lambda.blinkit.com/droid-dex-1f807901626f
       // Implement image quality optimization
    }
    ```
+
+3. **Heat-Aware Workloads**: Sustained work such as video export, on-device inference or camera capture makes the
+   device hot, and the platform then throttles it regardless of what the app wants. `THERMAL` reports how much
+   sustained performance is still available, so heavy work can be scaled back before the throttling bites:
+
+   ```Kotlin
+   DroidDex.getPerformanceLevelLd(PerformanceClass.THERMAL).observe(this) {
+      // Shed background work, lower encode quality or pause inference as the level drops
+   }
+   ```
+
+   `THERMAL` reports `UNKNOWN` below Android 10, where no public thermal API exists, and also on devices whose
+   hardware exposes no usable thermal sensor HAL (where a real reading is unavailable rather than "not throttling").
+   Since `UNKNOWN` parameters are excluded from aggregation, `THERMAL` only contributes when it has a trustworthy
+   signal, so it is safe to combine with other classes.
 
 ## Usage
 
@@ -118,6 +135,9 @@ The latest release is available on [Maven Central](https://central.sonatype.com/
 ```Kotlin
 implementation("com.eternal.kits:droid-dex:<<latest_version>>")
 ```
+
+Pre-release builds are published as `-betaNN` (e.g. `4.0.0-beta01`). Gradle treats them as pre-release
+versions, so dynamic versions and `latest.release` skip them - pin the exact string to opt in.
 
 </details>
 

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/battery/BatteryPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/battery/BatteryPerformanceManager.kt
@@ -9,7 +9,11 @@ import com.blinkit.droiddex.constants.PerformanceLevel
 import com.blinkit.droiddex.factory.base.PerformanceManager
 import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
 
-internal class BatteryPerformanceManager(private val applicationContext: Context): PerformanceManager() {
+/**
+ * Classifies battery readiness from the current charge percentage and charging state; charging
+ * earns each tier at a slightly lower percentage since the level is trending up.
+ */
+internal class BatteryPerformanceManager(applicationContext: Context): PerformanceManager(applicationContext) {
 
 	override fun getPerformanceClass() = PerformanceClass.BATTERY
 

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/constants/PerformanceClass.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/constants/PerformanceClass.kt
@@ -9,7 +9,8 @@ import androidx.annotation.Keep
 	PerformanceClass.MEMORY,
 	PerformanceClass.STORAGE,
 	PerformanceClass.NETWORK,
-	PerformanceClass.BATTERY
+	PerformanceClass.BATTERY,
+	PerformanceClass.THERMAL
 )
 @Retention(AnnotationRetention.SOURCE)
 @Target(
@@ -28,8 +29,9 @@ public annotation class PerformanceClass {
 		public const val STORAGE: Int = 2
 		public const val NETWORK: Int = 3
 		public const val BATTERY: Int = 4
+		public const val THERMAL: Int = 5
 
-		internal fun values(): List<Int> = listOf(CPU, MEMORY, STORAGE, NETWORK, BATTERY)
+		internal fun values(): List<Int> = listOf(CPU, MEMORY, STORAGE, NETWORK, BATTERY, THERMAL)
 
 		public fun @PerformanceClass Int.name() = when (this) {
 			CPU -> "CPU"
@@ -37,6 +39,7 @@ public annotation class PerformanceClass {
 			STORAGE -> "STORAGE"
 			NETWORK -> "NETWORK"
 			BATTERY -> "BATTERY"
+			THERMAL -> "THERMAL"
 			else -> this.toString()
 		}
 	}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
@@ -2,88 +2,169 @@ package com.blinkit.droiddex.cpu
 
 import android.content.Context
 import android.os.Build
-import androidx.annotation.RequiresApi
-import androidx.core.performance.play.services.PlayServicesDevicePerformance
 import com.blinkit.droiddex.constants.PerformanceClass
 import com.blinkit.droiddex.constants.PerformanceLevel
+import com.blinkit.droiddex.cpu.utils.CpuArchitectureScorer
 import com.blinkit.droiddex.cpu.utils.CpuInfoManager
 import com.blinkit.droiddex.factory.base.PerformanceManager
 import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
-import com.blinkit.droiddex.utils.getApproxHeapLimitInMB
+import com.blinkit.droiddex.utils.getMemoryClassInMB
 import com.blinkit.droiddex.utils.getTotalRamInGB
-import java.util.Locale
+import com.blinkit.droiddex.utils.isLowRamDevice
 
 /**
- * Inspired By <a href="https://github.com/DrKLO/Telegram/blob/dfd74f809e97d1ecad9672fc7388cb0223a95dfc/TMessagesProj/src/main/java/org/telegram/messenger/SharedConfig.java#L1361">Telegram's CPU Division</a>
+ * Classifies the device's CPU into a fixed hardware tier.
+ *
+ * The tier comes from a microarchitecture score ([CpuArchitectureScorer]) with two adjustments: a
+ * Media-Performance-Class certification overrides the score, and platform low-end signals
+ * ([measureHardwareCap]) cap the result so a fast SoC paired with starved memory never reports a
+ * rich-experience tier.
+ *
+ * Both hardware inputs are fixed, so they are measured once, persisted and served from cache on
+ * later launches; the cache invalidates only on a deliberate [CACHE_SCHEMA_VERSION] bump, and the
+ * certification gate stays outside it (see [applyPremiumGate]). Devices with no readable MIDR info
+ * (x86 emulators, restricted procfs) fall back to the hardware cap alone and are not cached.
  */
-internal class CpuPerformanceManager(private val applicationContext: Context): PerformanceManager() {
+internal class CpuPerformanceManager(applicationContext: Context): PerformanceManager(applicationContext) {
 
 	private val cpuInfoManager by lazy { CpuInfoManager(logger) }
 
-	private val devicePerformance by lazy { PlayServicesDevicePerformance(applicationContext) }
+	private val architectureScorer by lazy { CpuArchitectureScorer(logger) }
 
-	private val lowSocModels = intArrayOf(
-		-1775228513,  // EXYNOS 850
-		802464304,  // EXYNOS 7872
-		802464333,  // EXYNOS 7880
-		802464302,  // EXYNOS 7870
-		2067362118,  // MSM8953
-		2067362060,  // MSM8937
-		2067362084,  // MSM8940
-		2067362241,  // MSM8992
-		2067362117,  // MSM8952
-		2067361998,  // MSM8917
-		-1853602818 // SDM439
-	)
+	private val cachePrefs by lazy {
+		applicationContext.getSharedPreferences(CACHE_PREFS_NAME, Context.MODE_PRIVATE)
+	}
 
 	override fun getPerformanceClass() = PerformanceClass.CPU
 
 	override fun getDelayInSecs() = DELAY_IN_SECS
 
 	override fun measurePerformanceLevel(): PerformanceLevel {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-			val socModel = getBuildSocModel()
-			if (lowSocModels.any { it == socModel }) {
-				logInfo("SOC MODEL: $socModel IN LIST OF LOW SOC MODELS")
-				return PerformanceLevel.LOW
-			}
-		}
+		val (cachedScoredTier, cachedHardwareCap) = readCachedHardwareTiers() ?: return computeDeviceTier()
+		return applyPremiumGate(cachedScoredTier, cachedHardwareCap).also { logInfo("DEVICE TIER (CACHED): $it") }
+	}
 
-		val coresCount = cpuInfoManager.noOfCores.also { logger.logDebug("CORE COUNT: $it") }
+	private fun computeDeviceTier(): PerformanceLevel {
+		val hardwareCap = measureHardwareCap()
 
-		val maxCpuFreq = cpuInfoManager.maxCpuFreqInMHz
+		// No MIDR info: the hardware cap is the whole answer either way, and the procfs read may
+		// succeed on a later launch, so nothing is cached.
+		val scoredTier = measureMicroarchitectureTier()
+			?: return hardwareCap.also { logInfo("NO MICROARCHITECTURE INFO, DEVICE TIER (NOT CACHED): $it") }
 
+		writeCachedHardwareTiers(scoredTier, hardwareCap)
+		return applyPremiumGate(scoredTier, hardwareCap).also { logInfo("DEVICE TIER: $it") }
+	}
+
+	/**
+	 * Applied per read, never persisted: Play Services resolves the Media Performance Class
+	 * asynchronously, so a first-ever launch can read the framework default and miss a real
+	 * certification - caching that would make the miss permanent. A certified device is limited by
+	 * its hardware cap alone, since certification vouches for the SoC and not for the memory it is
+	 * paired with.
+	 */
+	private fun applyPremiumGate(scoredTier: PerformanceLevel, hardwareCap: PerformanceLevel): PerformanceLevel =
+		if (isPremiumCertified()) hardwareCap else minLevel(scoredTier, hardwareCap)
+
+	private fun measureMicroarchitectureTier(): PerformanceLevel? {
+		val score = architectureScorer.computeScore(cpuInfoManager.coreMaxFreqsInKHz) ?: return null
+		return when {
+			score < LOW_TIER_MAX_SCORE -> PerformanceLevel.LOW
+			score < AVERAGE_TIER_MAX_SCORE -> PerformanceLevel.AVERAGE
+			score < HIGH_TIER_MAX_SCORE -> PerformanceLevel.HIGH
+			else -> PerformanceLevel.EXCELLENT
+		}.also { logInfo("MICROARCHITECTURE SCORE: $score -> $it") }
+	}
+
+	/** Platform low-end signals cap the tier. Memory-class ranges start at 1 because 0 means "unknown". */
+	private fun measureHardwareCap(): PerformanceLevel {
 		val ramInGB = getTotalRamInGB(applicationContext, logger)
+		val memoryClassInMB = getMemoryClassInMB(applicationContext, logger)
+		val is64BitCapable = Build.SUPPORTED_64_BIT_ABIS.isNotEmpty()
 
-		val androidVersion = getAndroidVersion()
+		return when {
+			isLowRamDevice(applicationContext, logger) ||
+				!is64BitCapable ||
+				cpuInfoManager.noOfCores <= LOW_TIER_MAX_CORE_COUNT ||
+				(ramInGB > 0F && ramInGB < LOW_TIER_MAX_RAM_IN_GB) ||
+				memoryClassInMB in 1..LOW_TIER_MAX_MEMORY_CLASS_IN_MB -> PerformanceLevel.LOW
 
-		val mediaPerformanceClass = getMediaPerformanceClass()
+			(ramInGB > 0F && ramInGB < AVERAGE_TIER_MAX_RAM_IN_GB) ||
+				memoryClassInMB in 1..AVERAGE_TIER_MAX_MEMORY_CLASS_IN_MB -> PerformanceLevel.AVERAGE
 
-		val approxHeapLimitInMB = getApproxHeapLimitInMB(logger)
-
-		return if (mediaPerformanceClass >= Build.VERSION_CODES.TIRAMISU || ramInGB >= 12) {
-			PerformanceLevel.EXCELLENT
-		} else if (androidVersion < 21 || coresCount <= 2 || approxHeapLimitInMB <= 100 || coresCount <= 4 && maxCpuFreq <= 1250 || coresCount <= 4 && maxCpuFreq <= 1600 && approxHeapLimitInMB <= 128 && androidVersion <= 21 || coresCount <= 4 && maxCpuFreq <= 1300 && approxHeapLimitInMB <= 128 && androidVersion <= 24 || ramInGB <= 2) {
-			PerformanceLevel.LOW
-		} else if (coresCount < 8 || approxHeapLimitInMB <= 160 || maxCpuFreq <= 2055 || coresCount == 8 && androidVersion <= 23 || ramInGB <= 6) {
-			PerformanceLevel.AVERAGE
-		} else {
-			PerformanceLevel.HIGH
+			else -> PerformanceLevel.EXCELLENT
 		}
 	}
 
-	@RequiresApi(Build.VERSION_CODES.S)
-	private fun getBuildSocModel() = Build.SOC_MODEL.uppercase(Locale.getDefault()).hashCode()
+	/** Both halves must be present to be usable, so a partial write is treated as no cache at all. */
+	private fun readCachedHardwareTiers(): Pair<PerformanceLevel, PerformanceLevel>? = try {
+		if (cachePrefs.getInt(KEY_CACHE_SCHEMA_VERSION, 0) == CACHE_SCHEMA_VERSION) {
+			val scoredTier = readCachedLevel(KEY_SCORED_TIER_LEVEL)
+			val hardwareCap = readCachedLevel(KEY_HARDWARE_CAP_LEVEL)
+			if (scoredTier != null && hardwareCap != null) scoredTier to hardwareCap else null
+		} else null
+	} catch (e: Exception) {
+		logError(e)
+		null
+	}
 
-	private fun getMediaPerformanceClass() =
-		devicePerformance.mediaPerformanceClass.also { logDebug("MEDIA PERFORMANCE CLASS: $it") }
+	private fun readCachedLevel(key: String): PerformanceLevel? =
+		PerformanceLevel.getPerformanceLevel(cachePrefs.getInt(key, PerformanceLevel.UNKNOWN.level))
+			.takeIf { it != PerformanceLevel.UNKNOWN }
 
-	private fun getAndroidVersion() = Build.VERSION.SDK_INT.also { logDebug("ANDROID VERSION: $it") }
+	private fun writeCachedHardwareTiers(scoredTier: PerformanceLevel, hardwareCap: PerformanceLevel) {
+		try {
+			cachePrefs.edit()
+				.putInt(KEY_CACHE_SCHEMA_VERSION, CACHE_SCHEMA_VERSION)
+				.putInt(KEY_SCORED_TIER_LEVEL, scoredTier.level)
+				.putInt(KEY_HARDWARE_CAP_LEVEL, hardwareCap.level)
+				.apply()
+		} catch (e: Exception) {
+			logError(e)
+		}
+	}
+
+	private fun minLevel(a: PerformanceLevel, b: PerformanceLevel): PerformanceLevel =
+		PerformanceLevel.getPerformanceLevel(minOf(a.level, b.level))
 
 	companion object: PerformanceManagerProvider {
 
 		override fun create(applicationContext: Context): PerformanceManager = CpuPerformanceManager(applicationContext)
 
-		private const val DELAY_IN_SECS = 60F
+		// The tier is fixed hardware; the poll only exists to satisfy the periodic-manager contract.
+		private const val DELAY_IN_SECS = 600F
+
+		// Microarchitecture score boundaries (score = sum of core-weight x max-GHz over all cores),
+		// calibrated against public specs; representative SoCs per band:
+		// LOW < 20:        8xA53/A55 designs (Exynos 850 ~19, Unisoc T606 ~18.5)
+		// AVERAGE 20-34:   Helio G85 ~22, SD 680 ~27, Helio G99 ~27, SD 695 ~28, Exynos 1280 ~31
+		// HIGH 34-56:      SD 778G ~40, SD 888 ~44, Exynos 1480 ~47, 8 Gen 1 ~50, D9200 ~55
+		// EXCELLENT >= 56: 2022+ flagship silicon (Tensor G3 ~57, 8 Gen 2 ~63, 8 Elite ~130)
+		private const val LOW_TIER_MAX_SCORE = 20F
+		private const val AVERAGE_TIER_MAX_SCORE = 34F
+		private const val HIGH_TIER_MAX_SCORE = 56F
+
+		private const val LOW_TIER_MAX_CORE_COUNT = 2
+
+		// Real totalMem reads ~10% below marketing size; 3.6 sits between real 3GB (~2.9) and
+		// real 4GB (~3.5) readings.
+		private const val LOW_TIER_MAX_RAM_IN_GB = 2.8F
+		private const val AVERAGE_TIER_MAX_RAM_IN_GB = 3.6F
+
+		// Only small heap budgets are trusted (they reliably flag old/cheap hardware); deliberately
+		// looser than MemoryPerformanceManager's cutoffs since that axis owns heap-quota policing.
+		private const val LOW_TIER_MAX_MEMORY_CLASS_IN_MB = 100
+		private const val AVERAGE_TIER_MAX_MEMORY_CLASS_IN_MB = 160
+
+		private const val CACHE_PREFS_NAME = "com.blinkit.droiddex.cpu_tier_cache"
+		private const val KEY_CACHE_SCHEMA_VERSION = "cache_schema_version"
+
+		// Only the two hardware-derived inputs are cached; the premium gate is re-applied per read.
+		private const val KEY_SCORED_TIER_LEVEL = "scored_tier_level"
+		private const val KEY_HARDWARE_CAP_LEVEL = "hardware_cap_level"
+
+		// Bump when the scoring algorithm, core-weight table, tier thresholds or hardware cap
+		// change, so tiers cached by older logic are recomputed.
+		private const val CACHE_SCHEMA_VERSION = 1
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
@@ -1,0 +1,220 @@
+package com.blinkit.droiddex.cpu.utils
+
+import com.blinkit.droiddex.utils.Logger
+import java.io.File
+
+/**
+ * Estimates CPU capability from the device's core microarchitectures. Every ARM core exposes its
+ * design (MIDR) in /proc/cpuinfo as "CPU implementer" + "CPU part"; unlike core count or clock
+ * speed, the core design cannot be faked by OEMs.
+ *
+ * The score is a synthetic throughput estimate: sum over all cores of (relative single-thread
+ * weight of the core design) x (max frequency in GHz). A design absent from [KNOWN_CORE_WEIGHTS] is
+ * newer than the table, so it scores as the newest known core of its cluster role - future SoCs
+ * tier correctly without a library update.
+ */
+internal class CpuArchitectureScorer(
+	private val logger: Logger, private val cpuInfoPath: String = CPU_INFO_PATH
+) {
+
+	/**
+	 * @param coreMaxFreqsInKHz per-core cpuinfo_max_freq, index-aligned with cpu0..cpuN; <= 0 means unknown
+	 * @return the synthetic throughput score, or null when no MIDR info is readable (x86 emulator,
+	 * hidden procfs) - callers must then fall back to a heuristic that does not need it
+	 */
+	fun computeScore(coreMaxFreqsInKHz: List<Long>): Float? = try {
+		val midrIdsByCore = readCpuInfoText()?.let(::parseMidrIds).orEmpty()
+		if (midrIdsByCore.isEmpty()) null else computeScore(coreMaxFreqsInKHz, midrIdsByCore)
+	} catch (e: Exception) {
+		logger.logError(e)
+		null
+	}
+
+	private fun computeScore(coreMaxFreqsInKHz: List<Long>, midrIdsByCore: Map<Int, MidrId>): Float? {
+		val coreCount = maxOf(coreMaxFreqsInKHz.size, midrIdsByCore.keys.max() + 1)
+
+		val freqsInKHz = LongArray(coreCount) { maxOf(coreMaxFreqsInKHz.getOrElse(it) { 0L }, 0L) }
+		if (!repairUnknownFrequencies(freqsInKHz, midrIdsByCore)) return null
+
+		val deviceMaxFreqInKHz = freqsInKHz.max()
+		val topFreqCoreCount = freqsInKHz.count { it >= PRIME_ROLE_MIN_RELATIVE_FREQ * deviceMaxFreqInKHz }
+
+		var score = 0F
+		for (core in 0 until coreCount) {
+			val midrId = midrIdsByCore[core] ?: findClusterMateMidrId(core, freqsInKHz, midrIdsByCore)
+			val weight = midrId?.let { KNOWN_CORE_WEIGHTS[it] } ?: run {
+				val roleWeight = roleBasedWeight(freqsInKHz[core], deviceMaxFreqInKHz, topFreqCoreCount)
+				val coreDesign = midrId?.let { "UNKNOWN CORE DESIGN $it" } ?: "NO CORE DESIGN"
+				logger.logDebug("$coreDesign ON CPU$core, ROLE-BASED WEIGHT: $roleWeight")
+				roleWeight
+			}
+			score += weight * freqsInKHz[core] / KHZ_PER_GHZ
+		}
+		return score.also { logger.logDebug("MICROARCHITECTURE SCORE: $it") }
+	}
+
+	/**
+	 * Fills frequencies of cores whose cpufreq node was unreadable from a cluster mate with the same
+	 * core design, else from the device average. False when no frequency is known at all.
+	 */
+	private fun repairUnknownFrequencies(freqsInKHz: LongArray, midrIdsByCore: Map<Int, MidrId>): Boolean {
+		val knownFreqs = freqsInKHz.filter { it > 0 }
+		if (knownFreqs.isEmpty()) return false
+
+		val averageFreq = (knownFreqs.sum() / knownFreqs.size)
+		for (core in freqsInKHz.indices) {
+			if (freqsInKHz[core] > 0) continue
+			freqsInKHz[core] = midrIdsByCore[core]?.let { id ->
+				freqsInKHz.indices.firstOrNull { freqsInKHz[it] > 0 && midrIdsByCore[it] == id }
+					?.let { freqsInKHz[it] }
+			} ?: averageFreq
+		}
+		return true
+	}
+
+	/** Cores missing from /proc/cpuinfo (offline during the read) inherit the design of a same-frequency mate. */
+	private fun findClusterMateMidrId(core: Int, freqsInKHz: LongArray, midrIdsByCore: Map<Int, MidrId>): MidrId? =
+		freqsInKHz.indices.firstOrNull { midrIdsByCore[it] != null && freqsInKHz[it] == freqsInKHz[core] }
+			?.let { midrIdsByCore[it] }
+
+	/** Weight for a design not in the table: assume the newest known core of the same cluster role. */
+	private fun roleBasedWeight(freqInKHz: Long, deviceMaxFreqInKHz: Long, topFreqCoreCount: Int): Float {
+		val relativeFreq = freqInKHz.toFloat() / deviceMaxFreqInKHz
+		return when {
+			relativeFreq < EFFICIENCY_ROLE_MAX_RELATIVE_FREQ -> UNKNOWN_EFFICIENCY_CORE_WEIGHT
+			relativeFreq < PRIME_ROLE_MIN_RELATIVE_FREQ -> UNKNOWN_BIG_CORE_WEIGHT
+			// Real designs ship at most 1-2 prime cores; a bigger same-top-frequency group is a
+			// big cluster, so scoring it as primes would overrate the device.
+			topFreqCoreCount <= MAX_PRIME_CORE_COUNT -> UNKNOWN_PRIME_CORE_WEIGHT
+			else -> UNKNOWN_BIG_CORE_WEIGHT
+		}
+	}
+
+	private fun readCpuInfoText(): String? = try {
+		File(cpuInfoPath).readText()
+	} catch (e: Exception) {
+		logger.logDebug("COULD NOT READ $cpuInfoPath: ${e.message}")
+		null
+	}
+
+	private fun parseMidrIds(cpuInfoText: String): Map<Int, MidrId> {
+		val implementers = mutableMapOf<Int, Int>()
+		val parts = mutableMapOf<Int, Int>()
+		var currentCore = -1
+
+		for (line in cpuInfoText.lineSequence()) {
+			val separatorIndex = line.indexOf(':')
+			if (separatorIndex < 0) continue
+			val key = line.substring(0, separatorIndex).trim().lowercase()
+			val value = line.substring(separatorIndex + 1).trim()
+			when (key) {
+				// Non-numeric "Processor : ARMv8..." header lines parse to null and are ignored
+				"processor" -> value.toIntOrNull()?.let { currentCore = it }
+				"cpu implementer" -> parseNumber(value)?.let { if (currentCore >= 0) implementers[currentCore] = it }
+				"cpu part" -> parseNumber(value)?.let { if (currentCore >= 0) parts[currentCore] = it }
+			}
+		}
+
+		return parts.mapNotNull { (core, part) ->
+			implementers[core]?.let { implementer -> core to MidrId(implementer, part) }
+		}.toMap()
+	}
+
+	private fun parseNumber(value: String): Int? =
+		if (value.startsWith("0x")) value.removePrefix("0x").toIntOrNull(16) else value.toIntOrNull()
+
+	internal data class MidrId(val implementer: Int, val part: Int)
+
+	companion object {
+
+		private const val CPU_INFO_PATH = "/proc/cpuinfo"
+
+		private const val KHZ_PER_GHZ = 1_000_000F
+
+		private const val ARM = 0x41
+		private const val HISILICON = 0x48
+		private const val QUALCOMM = 0x51
+		private const val SAMSUNG = 0x53
+
+		/** A core clocked below 72% of the device's fastest core is in an efficiency cluster. */
+		private const val EFFICIENCY_ROLE_MAX_RELATIVE_FREQ = 0.72F
+
+		/** A core clocked at 95%+ of the device maximum shares the prime role. */
+		private const val PRIME_ROLE_MIN_RELATIVE_FREQ = 0.95F
+
+		/** More cores than this at the top frequency means a big cluster, not prime cores. */
+		private const val MAX_PRIME_CORE_COUNT = 2
+
+		// Fallback weights for unknown (i.e. newer-than-table) designs = newest known core of that role.
+		private const val UNKNOWN_EFFICIENCY_CORE_WEIGHT = 1.5F
+		private const val UNKNOWN_BIG_CORE_WEIGHT = 4.1F
+		private const val UNKNOWN_PRIME_CORE_WEIGHT = 5.2F
+
+		private fun arm(part: Int) = MidrId(ARM, part)
+		private fun hisilicon(part: Int) = MidrId(HISILICON, part)
+		private fun qualcomm(part: Int) = MidrId(QUALCOMM, part)
+		private fun samsung(part: Int) = MidrId(SAMSUNG, part)
+
+		/**
+		 * Relative single-thread capability per GHz, coarsely anchored to public Geekbench 6
+		 * single-core results (unitless - only ratios and the tier thresholds matter). Keyed by core
+		 * design, not SoC: ARM ships ~3 mobile ids per year.
+		 */
+		private val KNOWN_CORE_WEIGHTS: Map<MidrId, Float> = mapOf(
+			// ARM efficiency cores
+			arm(0xd03) to 1.0F, // Cortex-A53
+			arm(0xd04) to 1.0F, // Cortex-A35
+			arm(0xd05) to 1.2F, // Cortex-A55
+			arm(0xd46) to 1.4F, // Cortex-A510
+			arm(0xd80) to 1.5F, // Cortex-A520
+			arm(0xd8f) to 1.5F, // Cortex-A320
+			arm(0xd8a) to 1.6F, // C1-Nano
+			// ARM big cores, ARMv8 2016-18
+			arm(0xd07) to 1.6F, // Cortex-A57
+			arm(0xd08) to 1.9F, // Cortex-A72
+			arm(0xd09) to 2.0F, // Cortex-A73
+			arm(0xd0a) to 2.2F, // Cortex-A75
+			// ARM big cores, ARMv8 2019-21
+			arm(0xd0b) to 2.8F, // Cortex-A76
+			arm(0xd0d) to 3.1F, // Cortex-A77
+			arm(0xd41) to 3.4F, // Cortex-A78
+			arm(0xd4b) to 3.4F, // Cortex-A78C
+			arm(0xd44) to 3.9F, // Cortex-X1
+			arm(0xd4c) to 3.9F, // Cortex-X1C
+			// ARM big cores, ARMv9 gen 1-2
+			arm(0xd47) to 3.6F, // Cortex-A710
+			arm(0xd4d) to 3.7F, // Cortex-A715
+			arm(0xd48) to 4.1F, // Cortex-X2
+			arm(0xd4e) to 4.4F, // Cortex-X3
+			// ARM big cores, ARMv9 gen 3+
+			arm(0xd81) to 3.9F, // Cortex-A720
+			arm(0xd87) to 4.1F, // Cortex-A725
+			arm(0xd82) to 4.7F, // Cortex-X4
+			arm(0xd85) to 5.2F, // Cortex-X925
+			arm(0xd8b) to 4.3F, // C1-Pro
+			arm(0xd90) to 5.0F, // C1-Premium
+			arm(0xd8c) to 5.6F, // C1-Ultra
+			// HiSilicon (Kirin) relabels licensed ARM designs under its own implementer id, so the
+			// same part number means a different core than under ARM: 0xd41 is A77 here, A78 there.
+			hisilicon(0xd40) to 2.8F, // Cortex-A76 (Kirin 980/990)
+			hisilicon(0xd41) to 3.1F, // Cortex-A77 (Kirin 9000)
+			hisilicon(0xd01) to 2.2F, // TaiShan v110 (Kunpeng, server)
+			hisilicon(0xd02) to 2.8F, // TaiShan v120 (Kunpeng, server)
+			// Qualcomm custom + semi-custom (rebranded ARM) designs
+			qualcomm(0x001) to 5.0F, // Oryon
+			qualcomm(0x205) to 1.8F, // Kryo 1xx Gold (SD 820/821)
+			qualcomm(0x211) to 1.6F, // Kryo 1xx Silver
+			qualcomm(0x800) to 2.0F, // Kryo 2xx Gold (A73-class)
+			qualcomm(0x801) to 1.0F, // Kryo 2xx Silver (A53-class)
+			qualcomm(0x802) to 2.2F, // Kryo 3xx Gold (A75-class)
+			qualcomm(0x803) to 1.2F, // Kryo 3xx Silver (A55-class)
+			qualcomm(0x804) to 2.8F, // Kryo 4xx Gold (A76-class)
+			qualcomm(0x805) to 1.2F, // Kryo 4xx Silver (A55-class)
+			// Samsung custom big cores (Exynos M-series, discontinued 2020)
+			samsung(0x001) to 1.7F, // Mongoose M1/M2
+			samsung(0x002) to 2.2F, // Mongoose M3
+			samsung(0x003) to 2.6F, // Mongoose M4
+			samsung(0x004) to 2.7F, // Mongoose M5
+		)
+	}
+}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuInfoManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuInfoManager.kt
@@ -21,21 +21,31 @@ internal class CpuInfoManager(private val logger: Logger) {
 		)
 	}
 
+	/** Per-core cpuinfo_max_freq in kHz, index-aligned with cpu0..cpuN; 0 means unknown. */
+	val coreMaxFreqsInKHz: List<Long>
+		get() = coresFreqList.map { it.max }
+
+	/** Per-core cpuinfo_min_freq in kHz, index-aligned with cpu0..cpuN; 0 means unknown. */
+	val coreMinFreqsInKHz: List<Long>
+		get() = coresFreqList.map { it.min }
+
 	val currentCpuUsage: Int
 		get() = (coresFreqList.map { it.currentUsagePercent }.average()?.toInt()
 			?: 0).also { logger.logDebug("CURRENT USAGE: ${it}%") }
 
 	val maxCpuFreqInMHz: Int
-		get() = ((coresFreqList.map { it.max }.average()?.toLong()?.takeIf { it > 0 }?.div(1000)?.toInt())
-			?: Int.MAX_VALUE).also { logger.logDebug("MAX CPU FREQUENCY: $it MHz") }
+		get() = averageFreqInMHz(coreMaxFreqsInKHz).also { logger.logDebug("MAX CPU FREQUENCY: $it MHz") }
 
 	val minCpuFreqInMHz: Int
-		get() = ((coresFreqList.map { it.min }.average()?.toLong()?.takeIf { it > 0 }?.div(1000)?.toInt())
-			?: Int.MAX_VALUE).also { logger.logDebug("MIN CPU FREQUENCY: $it MHz") }
+		get() = averageFreqInMHz(coreMinFreqsInKHz).also { logger.logDebug("MIN CPU FREQUENCY: $it MHz") }
 
 	init {
 		for (i in 0 until noOfCores) coresFreqList.add(CoreFreq(i))
 	}
+
+	/** Mean of the per-core frequencies in MHz; [Int.MAX_VALUE] when no frequency is readable. */
+	private fun averageFreqInMHz(coreFreqsInKHz: List<Long>): Int =
+		coreFreqsInKHz.average()?.toLong()?.takeIf { it > 0 }?.div(KHZ_PER_MHZ)?.toInt() ?: Int.MAX_VALUE
 
 	private class CoreFreq(private val index: Int) {
 
@@ -82,5 +92,7 @@ internal class CpuInfoManager(private val logger: Logger) {
 	companion object {
 
 		private const val CPU_INFO_PATH = "/sys/devices/system/cpu/"
+
+		private const val KHZ_PER_MHZ = 1000
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/base/PerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/base/PerformanceManager.kt
@@ -1,14 +1,17 @@
 package com.blinkit.droiddex.factory.base
 
+import android.content.Context
+import android.os.Build
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.blinkit.droiddex.constants.PerformanceClass
 import com.blinkit.droiddex.constants.PerformanceLevel
+import com.blinkit.droiddex.utils.DevicePerformanceProvider
 import com.blinkit.droiddex.utils.Logger
 import com.blinkit.droiddex.utils.runAsyncPeriodically
 import kotlin.concurrent.Volatile
 
-internal abstract class PerformanceManager {
+internal abstract class PerformanceManager(protected val applicationContext: Context) {
 
 	@Volatile
 	var performanceLevel = PerformanceLevel.UNKNOWN
@@ -21,20 +24,32 @@ internal abstract class PerformanceManager {
 	protected val logger by lazy { Logger(getPerformanceClass()) }
 
 	fun init() {
-		runAsyncPeriodically({
-			try {
-				measurePerformanceLevel().also {
-					val hasPerformanceLevelChanged = performanceLevelLd.value != it
-					if (hasPerformanceLevelChanged) {
-						performanceLevel = it
-						_performanceLevelLd.postValue(it)
-					}
-					logger.logPerformanceLevelChange(it, hasPerformanceLevelChanged)
+		runAsyncPeriodically({ measureAndPublish() }, delayInSecs = getDelayInSecs())
+	}
+
+	/**
+	 * Measures once and publishes the result if it changed. Shared by the periodic poller and by
+	 * event-driven re-measures (e.g. the memory manager's onTrimMemory fast path), which must not
+	 * interleave. A JVM lock (not a coroutine Mutex) is intentional: nothing inside suspends, so
+	 * the monitor is only held across plain blocking work — keep it that way.
+	 */
+	@Synchronized
+	protected fun measureAndPublish() {
+		try {
+			measurePerformanceLevel().also {
+				// Compared against the field, not performanceLevelLd.value: postValue applies
+				// asynchronously, so the LiveData can lag and a rapid second call would re-post
+				// a duplicate.
+				val hasPerformanceLevelChanged = performanceLevel != it
+				if (hasPerformanceLevelChanged) {
+					performanceLevel = it
+					_performanceLevelLd.postValue(it)
 				}
-			} catch (e: Exception) {
-				logger.logError(e)
+				logger.logPerformanceLevelChange(it, hasPerformanceLevelChanged)
 			}
-		}, delayInSecs = getDelayInSecs())
+		} catch (e: Exception) {
+			logger.logError(e)
+		}
 	}
 
 	@PerformanceClass
@@ -44,9 +59,26 @@ internal abstract class PerformanceManager {
 
 	protected abstract fun measurePerformanceLevel(): PerformanceLevel
 
+	/**
+	 * Whether the OEM certified this device for Media Performance Class
+	 * [MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS]+ (flagship class). Lives in the base so every axis that
+	 * needs a premium-hardware gate shares one definition.
+	 *
+	 * Play Services resolves the real value asynchronously; until that first resolution is
+	 * persisted, this can read the framework default (usually 0) and report false on the very
+	 * first launch.
+	 */
+	protected fun isPremiumCertified(): Boolean =
+		DevicePerformanceProvider.get(applicationContext).mediaPerformanceClass >= MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS
+
 	protected fun logInfo(message: String) = logger.logInfo(message)
 
 	protected fun logDebug(message: String) = logger.logDebug(message)
 
 	protected fun logError(throwable: Throwable) = logger.logError(throwable)
+
+	private companion object {
+
+		private const val MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS = Build.VERSION_CODES.TIRAMISU
+	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/factory/PerformanceManagerFactory.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/factory/factory/PerformanceManagerFactory.kt
@@ -10,6 +10,7 @@ import com.blinkit.droiddex.factory.base.PerformanceManager
 import com.blinkit.droiddex.memory.MemoryPerformanceManager
 import com.blinkit.droiddex.network.NetworkPerformanceManager
 import com.blinkit.droiddex.storage.StoragePerformanceManager
+import com.blinkit.droiddex.thermal.ThermalPerformanceManager
 
 internal class PerformanceManagerFactory(private val applicationContext: Context) {
 
@@ -33,6 +34,7 @@ internal class PerformanceManagerFactory(private val applicationContext: Context
 				PerformanceClass.STORAGE -> StoragePerformanceManager.create(applicationContext)
 				PerformanceClass.NETWORK -> NetworkPerformanceManager.create(applicationContext)
 				PerformanceClass.BATTERY -> BatteryPerformanceManager.create(applicationContext)
+				PerformanceClass.THERMAL -> ThermalPerformanceManager.create(applicationContext)
 				else -> throw IllegalArgumentException("NO SUCH PERFORMANCE CLASS EXISTS: $performanceClass")
 			}.apply { init() }
 		}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/memory/MemoryPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/memory/MemoryPerformanceManager.kt
@@ -1,42 +1,344 @@
 package com.blinkit.droiddex.memory
 
+import android.app.ActivityManager
+import android.content.ComponentCallbacks2
 import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.os.SystemClock
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.blinkit.droiddex.constants.PerformanceClass
 import com.blinkit.droiddex.constants.PerformanceLevel
 import com.blinkit.droiddex.factory.base.PerformanceManager
 import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
-import com.blinkit.droiddex.utils.getApproxHeapLimitInMB
-import com.blinkit.droiddex.utils.getApproxHeapRemainingInMB
-import com.blinkit.droiddex.utils.getAvailableRamInGB
+import com.blinkit.droiddex.utils.getHeapUsedRatio
+import com.blinkit.droiddex.utils.getMemoryClassInMB
 import com.blinkit.droiddex.utils.getMemoryInfo
+import com.blinkit.droiddex.utils.getTotalRamInGB
+import com.blinkit.droiddex.utils.isLowRamDevice
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-internal class MemoryPerformanceManager(private val applicationContext: Context): PerformanceManager() {
+/**
+ * Reports memory performance as a stable, hardware-derived device tier that live pressure can
+ * only downgrade, never raise.
+ *
+ * Tier: total RAM proposes it, the Java-heap quota ([ActivityManager.getMemoryClass]) can only
+ * veto it - a low quota is enforced by ART with an [OutOfMemoryError], while a high one is just
+ * an OEM config value that physical RAM may not back.
+ *
+ * Pressure ([Pressure]) follows the shape of Chromium's Android memory-pressure monitor: polled
+ * system state is the primary signal on every API level and the platform trim callbacks only
+ * shorten detection latency, since they are unreliable across OEMs and API levels. MODERATE and
+ * SEVERE downgrade relative to the tier; CRITICAL - the OS is at its process-killing threshold -
+ * floors to LOW outright. Downgrades apply immediately, recoveries must hold for
+ * [UPGRADE_STABILITY_IN_MS] so GC churn does not flap the level.
+ */
+internal class MemoryPerformanceManager(
+	applicationContext: Context
+): PerformanceManager(applicationContext), ComponentCallbacks2 {
+
+	/** Ordinal order is severity order - comparisons and [maxOf] rely on it. */
+	private enum class Pressure { NONE, MODERATE, SEVERE, CRITICAL }
+
+	/** Fixed hardware tier; latched only on a successful measurement. */
+	@Volatile
+	private var cachedDeviceTier: PerformanceLevel? = null
+
+	// Hysteresis + streak state: only touched inside measurePerformanceLevel(), which the base
+	// class always calls under the measureAndPublish() monitor.
+	private var lastReportedLevel = PerformanceLevel.UNKNOWN
+	private var upgradeCandidateLevel = PerformanceLevel.UNKNOWN
+	private var upgradeCandidateSinceMs = 0L
+	private var consecutiveSevereHeapSamples = 0
+	private var lastCountedSevereHeapSampleAtMs = 0L
+
+	// One timestamp per trim severity (0 = inactive); sole writer is the main thread. Readers never
+	// pair two of them, so there is no write-ordering subtlety.
+	@Volatile
+	private var moderateTrimAtMs = 0L
+
+	@Volatile
+	private var severeTrimAtMs = 0L
+
+	@Volatile
+	private var criticalTrimAtMs = 0L
+
+	@Volatile
+	private var hasPendingImmediateRemeasure = false
+
+	init {
+		runCatching { applicationContext.registerComponentCallbacks(this) }.onFailure { logError(it) }
+	}
 
 	override fun getPerformanceClass() = PerformanceClass.MEMORY
 
 	override fun getDelayInSecs() = DELAY_IN_SECS
 
 	override fun measurePerformanceLevel(): PerformanceLevel {
-		if (getMemoryInfo(applicationContext, logger).lowMemory) {
-			logInfo("DEVICE HAS LOW MEMORY")
-			return PerformanceLevel.LOW
+		val tier = deviceTier()
+		if (tier == PerformanceLevel.UNKNOWN) return PerformanceLevel.UNKNOWN
+
+		val measuredLevel = tier.applyPressure(measurePressure())
+		return applyUpgradeHysteresis(measuredLevel)
+	}
+
+	private fun deviceTier(): PerformanceLevel = cachedDeviceTier ?: measureDeviceTier().also {
+		if (it != PerformanceLevel.UNKNOWN) cachedDeviceTier = it
+	}
+
+	private fun measureDeviceTier(): PerformanceLevel {
+		val ramTier = measureRamTier()
+		val heapQuotaCeiling = measureHeapQuotaCeiling()
+
+		return (listOfNotNull(ramTier, heapQuotaCeiling).minOrNull() ?: PerformanceLevel.UNKNOWN).also {
+			logInfo("DEVICE TIER: $it (RAM TIER: $ramTier, HEAP QUOTA CEILING: $heapQuotaCeiling)")
+		}
+	}
+
+	/** Null when the reading is unavailable: abstain rather than classify LOW on a zeroed MemoryInfo. */
+	private fun measureRamTier(): PerformanceLevel? {
+		if (isLowRamDevice(applicationContext, logger)) return PerformanceLevel.LOW
+
+		val totalRamInGB = getTotalRamInGB(applicationContext, logger)
+
+		return when {
+			totalRamInGB <= 0F -> null
+
+			totalRamInGB < LOW_TIER_MAX_RAM_IN_GB -> PerformanceLevel.LOW
+
+			totalRamInGB < AVERAGE_TIER_MAX_RAM_IN_GB -> PerformanceLevel.AVERAGE
+
+			totalRamInGB >= EXCELLENT_TIER_MIN_RAM_IN_GB || isPremiumCertified() -> PerformanceLevel.EXCELLENT
+
+			else -> PerformanceLevel.HIGH
+		}
+	}
+
+	/** The heap quota caps the tier but never raises it; null (unavailable) means no veto. */
+	private fun measureHeapQuotaCeiling(): PerformanceLevel? {
+		val memoryClassInMB = getMemoryClassInMB(applicationContext, logger)
+
+		return when {
+			memoryClassInMB <= 0 -> null
+
+			memoryClassInMB <= LOW_TIER_MAX_MEMORY_CLASS_IN_MB -> PerformanceLevel.LOW
+
+			memoryClassInMB <= AVERAGE_TIER_MAX_MEMORY_CLASS_IN_MB -> PerformanceLevel.AVERAGE
+
+			memoryClassInMB < EXCELLENT_TIER_MIN_MEMORY_CLASS_IN_MB -> PerformanceLevel.HIGH
+
+			else -> PerformanceLevel.EXCELLENT
+		}
+	}
+
+	private fun measurePressure(): Pressure {
+		val memoryInfo = getMemoryInfo(applicationContext, logger)
+		val heapUsedRatio = getHeapUsedRatio(logger)
+
+		updateSevereHeapStreak(heapUsedRatio)
+
+		val polled = when {
+			memoryInfo.lowMemory -> {
+				logInfo("PRESSURE: CRITICAL (SYSTEM LOW MEMORY)")
+				Pressure.CRITICAL
+			}
+
+			consecutiveSevereHeapSamples >= SEVERE_HEAP_CONFIRMATION_SAMPLES -> {
+				logInfo("PRESSURE: SEVERE (HEAP USED RATIO: $heapUsedRatio, CONFIRMED)")
+				Pressure.SEVERE
+			}
+
+			consecutiveSevereHeapSamples > 0 -> {
+				// Unconfirmed severe sample: one step now, confirm (or clear) within seconds.
+				logInfo("PRESSURE: MODERATE (HEAP USED RATIO: $heapUsedRatio, AWAITING CONFIRMATION)")
+				remeasureAsync(delayInMs = SEVERE_CONFIRMATION_DELAY_IN_MS)
+				Pressure.MODERATE
+			}
+
+			heapUsedRatio >= MODERATE_HEAP_USED_RATIO || isSystemMemoryStrained(memoryInfo) -> {
+				logInfo("PRESSURE: MODERATE")
+				Pressure.MODERATE
+			}
+
+			else -> Pressure.NONE
 		}
 
-		val availableRamInGB = getAvailableRamInGB(applicationContext, logger)
+		return maxOf(polled, activeTrimPressure(memoryInfo))
+	}
 
-		val approxHeapLimitInMB = getApproxHeapLimitInMB(logger)
-
-		val approxHeapRemainingInMB = getApproxHeapRemainingInMB(logger)
-
-		return if (approxHeapRemainingInMB <= 64 || approxHeapLimitInMB < 128) {
-			PerformanceLevel.LOW
-		} else if (approxHeapRemainingInMB <= 128 || approxHeapLimitInMB < 256 || availableRamInGB <= 2) {
-			PerformanceLevel.AVERAGE
-		} else if (approxHeapRemainingInMB <= 256 || availableRamInGB <= 3) {
-			PerformanceLevel.HIGH
-		} else {
-			PerformanceLevel.EXCELLENT
+	/**
+	 * A single heap sample can read high on not-yet-collected garbage, so SEVERE needs a confirmed
+	 * streak: samples closer together than a GC can plausibly run count once, and a stale streak
+	 * (backgrounded polling) restarts rather than pairing samples minutes apart.
+	 */
+	private fun updateSevereHeapStreak(heapUsedRatio: Float) {
+		if (heapUsedRatio < SEVERE_HEAP_USED_RATIO) {
+			consecutiveSevereHeapSamples = 0
+			lastCountedSevereHeapSampleAtMs = 0L
+			return
 		}
+
+		val now = SystemClock.elapsedRealtime()
+		val sinceLastCountedMs = now - lastCountedSevereHeapSampleAtMs
+		when {
+			consecutiveSevereHeapSamples == 0 || sinceLastCountedMs > SEVERE_HEAP_STREAK_STALENESS_IN_MS -> {
+				consecutiveSevereHeapSamples = 1
+				lastCountedSevereHeapSampleAtMs = now
+			}
+
+			sinceLastCountedMs >= SEVERE_HEAP_MIN_SAMPLE_SPACING_IN_MS -> {
+				consecutiveSevereHeapSamples++
+				lastCountedSevereHeapSampleAtMs = now
+			}
+		}
+	}
+
+	/**
+	 * Latest-wins downward: each trim is the OS's current assessment, so a milder signal ends any
+	 * severer downgrade instead of extending it.
+	 */
+	override fun onTrimMemory(level: Int) {
+		val severity = mapTrimLevelToPressure(level)
+		if (severity == Pressure.NONE) return
+
+		val now = SystemClock.elapsedRealtime()
+		val previousSeverity = activeRawTrimPressure(now)
+
+		if (severity < Pressure.CRITICAL) criticalTrimAtMs = 0L
+		if (severity < Pressure.SEVERE) severeTrimAtMs = 0L
+
+		when (severity) {
+			Pressure.CRITICAL -> criticalTrimAtMs = now
+			Pressure.SEVERE -> severeTrimAtMs = now
+			Pressure.MODERATE -> moderateTrimAtMs = now
+			Pressure.NONE -> Unit
+		}
+		logInfo("TRIM SIGNAL (LEVEL: $level) -> $severity")
+
+		// Storm guard: a refreshed timestamp alone doesn't need an immediate publish.
+		if (activeRawTrimPressure(now) != previousSeverity) remeasureAsync()
+	}
+
+	@Suppress("DEPRECATION")
+	override fun onLowMemory() = onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+
+	override fun onConfigurationChanged(newConfig: Configuration) = Unit
+
+	/**
+	 * UI_HIDDEN is a lifecycle event, not memory pressure. The deprecated mappings stay as
+	 * defensive code for OEM ROMs that still send them.
+	 */
+	@Suppress("DEPRECATION")
+	private fun mapTrimLevelToPressure(level: Int): Pressure = when {
+		level >= ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> Pressure.CRITICAL
+
+		level >= ComponentCallbacks2.TRIM_MEMORY_MODERATE -> Pressure.SEVERE
+
+		level >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND ->
+			if (IS_TRIM_BACKGROUND_LIFECYCLE_ONLY) Pressure.NONE else Pressure.MODERATE
+
+		level == ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> Pressure.NONE
+
+		level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> Pressure.CRITICAL
+
+		level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE -> Pressure.MODERATE
+
+		else -> Pressure.NONE
+	}
+
+	/** Trim signals expire per-severity rather than pinning the level down forever. */
+	private fun activeRawTrimPressure(nowMs: Long = SystemClock.elapsedRealtime()): Pressure = when {
+		isTrimActive(criticalTrimAtMs, CRITICAL_TRIM_VALIDITY_IN_MS, nowMs) -> Pressure.CRITICAL
+
+		isTrimActive(severeTrimAtMs, SEVERE_TRIM_VALIDITY_IN_MS, nowMs) -> Pressure.SEVERE
+
+		isTrimActive(moderateTrimAtMs, MODERATE_TRIM_VALIDITY_IN_MS, nowMs) -> Pressure.MODERATE
+
+		else -> Pressure.NONE
+	}
+
+	/**
+	 * A trim-originated CRITICAL floors to LOW only when the polled system state corroborates it
+	 * (pre-34 OEM ROMs fire TRIM_MEMORY_COMPLETE on routine backgrounding); uncorroborated it
+	 * counts as SEVERE.
+	 */
+	private fun activeTrimPressure(memoryInfo: ActivityManager.MemoryInfo): Pressure {
+		val severity = activeRawTrimPressure()
+		if (severity != Pressure.CRITICAL) return severity
+
+		val isCorroborated =
+			memoryInfo.lowMemory || (memoryInfo.threshold > 0 && memoryInfo.availMem <= memoryInfo.threshold)
+		return if (isCorroborated) Pressure.CRITICAL else Pressure.SEVERE
+	}
+
+	private fun isTrimActive(stampMs: Long, validityMs: Long, nowMs: Long): Boolean =
+		stampMs != 0L && nowMs - stampMs <= validityMs
+
+	/**
+	 * Publishes without waiting for the next poll tick, and works while polling is paused in the
+	 * background. Immediate calls are coalesced so trim bursts cannot queue unbounded measures.
+	 */
+	private fun remeasureAsync(delayInMs: Long = 0L) {
+		if (delayInMs == 0L) {
+			if (hasPendingImmediateRemeasure) return
+			hasPendingImmediateRemeasure = true
+		}
+		ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.IO) {
+			if (delayInMs > 0L) delay(delayInMs) else hasPendingImmediateRemeasure = false
+			measureAndPublish()
+		}
+	}
+
+	/** Close to the point where the OS starts killing processes; threshold 0 means the signal is unavailable. */
+	private fun isSystemMemoryStrained(memoryInfo: ActivityManager.MemoryInfo): Boolean =
+		memoryInfo.threshold > 0 && memoryInfo.availMem <= memoryInfo.threshold * SYSTEM_STRAIN_THRESHOLD_MULTIPLIER
+
+	private fun PerformanceLevel.applyPressure(pressure: Pressure): PerformanceLevel = when (pressure) {
+		Pressure.NONE -> this
+
+		Pressure.MODERATE -> downgradeBy(MODERATE_DOWNGRADE_STEPS)
+
+		Pressure.SEVERE -> downgradeBy(SEVERE_DOWNGRADE_STEPS)
+
+		// Absolute, not tier-relative: the OS is at its kill threshold and hardware is irrelevant.
+		Pressure.CRITICAL -> PerformanceLevel.LOW
+	}
+
+	private fun PerformanceLevel.downgradeBy(steps: Int): PerformanceLevel =
+		PerformanceLevel.getPerformanceLevel(maxOf(PerformanceLevel.LOW.level, level - steps))
+
+	/** Time-based, not tick-based: event-driven re-measures would inflate a tick counter. */
+	private fun applyUpgradeHysteresis(measuredLevel: PerformanceLevel): PerformanceLevel {
+		val isFirstMeasurement = lastReportedLevel == PerformanceLevel.UNKNOWN
+		if (isFirstMeasurement || measuredLevel.level <= lastReportedLevel.level) {
+			resetUpgradeCandidate()
+			lastReportedLevel = measuredLevel
+			return measuredLevel
+		}
+
+		val now = SystemClock.elapsedRealtime()
+		if (measuredLevel != upgradeCandidateLevel) {
+			upgradeCandidateLevel = measuredLevel
+			upgradeCandidateSinceMs = now
+			return lastReportedLevel
+		}
+
+		if (now - upgradeCandidateSinceMs >= UPGRADE_STABILITY_IN_MS) {
+			resetUpgradeCandidate()
+			lastReportedLevel = measuredLevel
+			return measuredLevel
+		}
+
+		return lastReportedLevel
+	}
+
+	private fun resetUpgradeCandidate() {
+		upgradeCandidateLevel = PerformanceLevel.UNKNOWN
+		upgradeCandidateSinceMs = 0L
 	}
 
 	companion object: PerformanceManagerProvider {
@@ -45,5 +347,43 @@ internal class MemoryPerformanceManager(private val applicationContext: Context)
 			MemoryPerformanceManager(applicationContext)
 
 		private const val DELAY_IN_SECS = 10F
+
+		private const val LOW_TIER_MAX_RAM_IN_GB = 2.8F
+
+		// Marketing 6GB reads ~5.5 real -> AVERAGE; marketing 8GB reads ~7.2-7.5 -> HIGH.
+		private const val AVERAGE_TIER_MAX_RAM_IN_GB = 6.9F
+
+		// Marketing 12GB reads ~10.8 real (a threshold of 12 would only match 16GB devices).
+		private const val EXCELLENT_TIER_MIN_RAM_IN_GB = 10.5F
+
+		private const val LOW_TIER_MAX_MEMORY_CLASS_IN_MB = 128
+		private const val AVERAGE_TIER_MAX_MEMORY_CLASS_IN_MB = 160
+
+		// Flagships ship 256+ (Pixels: heapgrowthlimit=256m).
+		private const val EXCELLENT_TIER_MIN_MEMORY_CLASS_IN_MB = 256
+
+		private const val MODERATE_HEAP_USED_RATIO = 0.75F
+		private const val SEVERE_HEAP_USED_RATIO = 0.90F
+		private const val SYSTEM_STRAIN_THRESHOLD_MULTIPLIER = 1.5F
+
+		private const val MODERATE_DOWNGRADE_STEPS = 1
+		private const val SEVERE_DOWNGRADE_STEPS = 2
+
+		private const val SEVERE_HEAP_CONFIRMATION_SAMPLES = 2
+		private const val SEVERE_CONFIRMATION_DELAY_IN_MS = 3_000L
+
+		// Must stay below SEVERE_CONFIRMATION_DELAY_IN_MS so the confirmation re-poll is countable.
+		private const val SEVERE_HEAP_MIN_SAMPLE_SPACING_IN_MS = 2_000L
+		private const val SEVERE_HEAP_STREAK_STALENESS_IN_MS = 30_000L
+
+		// Per-severity validity: long enough to bridge to the polled signal, short enough to recover.
+		private const val MODERATE_TRIM_VALIDITY_IN_MS = 15_000L
+		private const val SEVERE_TRIM_VALIDITY_IN_MS = 30_000L
+		private const val CRITICAL_TRIM_VALIDITY_IN_MS = 30_000L
+
+		private const val UPGRADE_STABILITY_IN_MS = 20_000L
+
+		// Android 14+: TRIM_MEMORY_BACKGROUND fires on entering the cached state, not on pressure.
+		private val IS_TRIM_BACKGROUND_LIFECYCLE_ONLY = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/network/NetworkPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/network/NetworkPerformanceManager.kt
@@ -18,7 +18,11 @@ import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
 import com.blinkit.droiddex.network.utils.BandwidthManager
 import com.blinkit.droiddex.utils.getPerformanceLevelWithWeights
 
-internal class NetworkPerformanceManager(private val applicationContext: Context): PerformanceManager() {
+/**
+ * Classifies current network quality from a weighted mix of the measured bandwidth average,
+ * the link's reported download speed and the WiFi/cellular signal strength; no internet reports LOW.
+ */
+internal class NetworkPerformanceManager(applicationContext: Context): PerformanceManager(applicationContext) {
 
 	private val bandwidthManager by lazy { BandwidthManager(logger) }
 

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/storage/StoragePerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/storage/StoragePerformanceManager.kt
@@ -9,7 +9,8 @@ import com.blinkit.droiddex.factory.base.PerformanceManager
 import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
 import com.blinkit.droiddex.utils.convertBytesToGB
 
-internal class StoragePerformanceManager: PerformanceManager() {
+/** Classifies free external-storage headroom in GB; 0 readable GB means the signal is unavailable. */
+internal class StoragePerformanceManager(applicationContext: Context): PerformanceManager(applicationContext) {
 
 	override fun getPerformanceClass() = PerformanceClass.STORAGE
 
@@ -39,7 +40,7 @@ internal class StoragePerformanceManager: PerformanceManager() {
 
 	companion object: PerformanceManagerProvider {
 
-		override fun create(applicationContext: Context): PerformanceManager = StoragePerformanceManager()
+		override fun create(applicationContext: Context): PerformanceManager = StoragePerformanceManager(applicationContext)
 
 		private const val DELAY_IN_SECS = 600F
 	}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/thermal/ThermalPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/thermal/ThermalPerformanceManager.kt
@@ -1,0 +1,231 @@
+package com.blinkit.droiddex.thermal
+
+import android.content.Context
+import android.os.Build
+import android.os.PowerManager
+import android.os.SystemClock
+import androidx.annotation.RequiresApi
+import com.blinkit.droiddex.constants.PerformanceClass
+import com.blinkit.droiddex.constants.PerformanceLevel
+import com.blinkit.droiddex.factory.base.PerformanceManager
+import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
+import kotlin.concurrent.Volatile
+
+/**
+ * Classifies how much sustained performance the device can currently deliver before the platform
+ * throttles it for heat: the thermal status maps onto the levels, and on API 30+ it is refined with
+ * `getThermalHeadroom`, which forecasts throttling early and can only pull the level down.
+ *
+ * A NONE status with no headroom reading is a device with no thermal HAL rather than a cool device,
+ * so it reports UNKNOWN instead of EXCELLENT (see [resolveNoneStatusWithoutHeadroom]) - on API 29,
+ * where no headroom API exists to disambiguate, NONE is taken at face value. Below API 29 there is
+ * no public thermal API at all, so this axis reports UNKNOWN and `DroidDex` drops it from
+ * aggregation.
+ */
+internal class ThermalPerformanceManager(applicationContext: Context): PerformanceManager(applicationContext) {
+
+	private val powerManager: PowerManager? by lazy {
+		applicationContext.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: run {
+			logError(Throwable("POWER MANAGER IS NULL"))
+			null
+		}
+	}
+
+	@Volatile
+	private var lastHeadroom = Float.NaN
+
+	/** Seeded a full interval in the past so the first reading is never suppressed. */
+	@Volatile
+	private var lastHeadroomAtMillis = -HEADROOM_MIN_INTERVAL_IN_MILLIS
+
+	/** Device-provided on API 35+, approximated by the constants below otherwise. */
+	@Volatile
+	private var headroomThresholds = HeadroomThresholds.DEFAULTS
+
+	override fun getPerformanceClass() = PerformanceClass.THERMAL
+
+	override fun getDelayInSecs() = DELAY_IN_SECS
+
+	override fun measurePerformanceLevel(): PerformanceLevel {
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+			logDebug("THERMAL STATUS UNAVAILABLE BELOW API 29")
+			return PerformanceLevel.UNKNOWN
+		}
+
+		val powerManager = powerManager ?: return PerformanceLevel.UNKNOWN
+		val performanceLevel = getPerformanceLevelFromStatus(powerManager)
+
+		return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			applyHeadroom(performanceLevel, powerManager)
+		} else {
+			performanceLevel
+		}
+	}
+
+	@RequiresApi(Build.VERSION_CODES.Q)
+	private fun getPerformanceLevelFromStatus(powerManager: PowerManager): PerformanceLevel {
+		val thermalStatus = try {
+			powerManager.currentThermalStatus
+		} catch (e: Exception) {
+			logError(e)
+			return PerformanceLevel.UNKNOWN
+		}
+
+		logDebug("THERMAL STATUS: ${thermalStatus.thermalStatusName()}")
+
+		// Everything at and beyond SEVERE collapses to LOW: the guidance for all of them is the
+		// same - shed load now.
+		return when (thermalStatus) {
+			PowerManager.THERMAL_STATUS_NONE -> PerformanceLevel.EXCELLENT
+			PowerManager.THERMAL_STATUS_LIGHT -> PerformanceLevel.HIGH
+			PowerManager.THERMAL_STATUS_MODERATE -> PerformanceLevel.AVERAGE
+			PowerManager.THERMAL_STATUS_SEVERE,
+			PowerManager.THERMAL_STATUS_CRITICAL,
+			PowerManager.THERMAL_STATUS_EMERGENCY,
+			PowerManager.THERMAL_STATUS_SHUTDOWN -> PerformanceLevel.LOW
+
+			else -> PerformanceLevel.UNKNOWN
+		}
+	}
+
+	/**
+	 * Lowers [performanceLevel] when throttling is forecast within [HEADROOM_FORECAST_IN_SECS];
+	 * never raises it.
+	 */
+	@RequiresApi(Build.VERSION_CODES.R)
+	private fun applyHeadroom(performanceLevel: PerformanceLevel, powerManager: PowerManager): PerformanceLevel {
+		val headroom = getThermalHeadroom(powerManager)
+		if (headroom.isNaN()) return resolveNoneStatusWithoutHeadroom(performanceLevel)
+
+		val thresholds = headroomThresholds
+		val ceiling = when {
+			headroom >= thresholds.severe -> PerformanceLevel.LOW
+			headroom >= thresholds.moderate -> PerformanceLevel.AVERAGE
+			headroom >= thresholds.light -> PerformanceLevel.HIGH
+			else -> return performanceLevel
+		}
+
+		return if (performanceLevel.level > ceiling.level) {
+			logDebug("THERMAL HEADROOM CAPPED LEVEL: ${performanceLevel.name} -> ${ceiling.name}")
+			ceiling
+		} else {
+			performanceLevel
+		}
+	}
+
+	/**
+	 * A device without a thermal HAL hardwires its status to NONE and its headroom to NaN, so
+	 * reporting EXCELLENT would inflate every aggregate on exactly the budget hardware most prone to
+	 * throttling. Any throttling status proves the HAL works and is left untouched.
+	 */
+	private fun resolveNoneStatusWithoutHeadroom(performanceLevel: PerformanceLevel): PerformanceLevel =
+		if (performanceLevel == PerformanceLevel.EXCELLENT) {
+			logDebug("THERMAL HEADROOM UNAVAILABLE (NO HAL): NONE STATUS UNTRUSTWORTHY -> UNKNOWN")
+			PerformanceLevel.UNKNOWN
+		} else {
+			performanceLevel
+		}
+
+	/**
+	 * `getThermalHeadroom` also returns NaN when over-polled, which would masquerade as an
+	 * unsupported device, so the reading is cached for [HEADROOM_MIN_INTERVAL_IN_MILLIS]. The
+	 * thresholds refresh on the same cadence because API 36+ may change them at runtime.
+	 */
+	@RequiresApi(Build.VERSION_CODES.R)
+	private fun getThermalHeadroom(powerManager: PowerManager): Float {
+		val now = SystemClock.elapsedRealtime()
+		if (now - lastHeadroomAtMillis < HEADROOM_MIN_INTERVAL_IN_MILLIS) return lastHeadroom
+
+		val headroom = try {
+			powerManager.getThermalHeadroom(HEADROOM_FORECAST_IN_SECS)
+		} catch (e: Exception) {
+			logError(e)
+			Float.NaN
+		}
+
+		lastHeadroom = headroom
+		lastHeadroomAtMillis = now
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+			headroomThresholds = resolveHeadroomThresholds(powerManager)
+		}
+
+		logDebug("THERMAL HEADROOM (${HEADROOM_FORECAST_IN_SECS}s FORECAST): $headroom")
+		return headroom
+	}
+
+	/**
+	 * Prefers the device's own `getThermalHeadroomThresholds` so the forecast reacts where this
+	 * hardware actually throttles. The map is legitimately partial, so each status falls back to its
+	 * constant individually; an inverted merged set falls back entirely.
+	 */
+	@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+	private fun resolveHeadroomThresholds(powerManager: PowerManager): HeadroomThresholds {
+		val deviceThresholds = try {
+			powerManager.thermalHeadroomThresholds
+		} catch (e: Exception) {
+			logError(e)
+			return HeadroomThresholds.DEFAULTS
+		}
+
+		val resolved = HeadroomThresholds(
+			light = deviceThresholds[PowerManager.THERMAL_STATUS_LIGHT] ?: LIGHT_HEADROOM,
+			moderate = deviceThresholds[PowerManager.THERMAL_STATUS_MODERATE] ?: MODERATE_HEADROOM,
+			severe = deviceThresholds[PowerManager.THERMAL_STATUS_SEVERE] ?: SEVERE_HEADROOM
+		)
+
+		if (!resolved.isMonotonic()) {
+			logDebug("THERMAL HEADROOM THRESHOLDS NOT MONOTONIC, USING DEFAULTS: $resolved")
+			return HeadroomThresholds.DEFAULTS
+		}
+
+		if (resolved != headroomThresholds) logDebug("THERMAL HEADROOM THRESHOLDS: $resolved")
+		return resolved
+	}
+
+	@RequiresApi(Build.VERSION_CODES.Q)
+	private fun Int.thermalStatusName(): String = when (this) {
+		PowerManager.THERMAL_STATUS_NONE -> "NONE"
+		PowerManager.THERMAL_STATUS_LIGHT -> "LIGHT"
+		PowerManager.THERMAL_STATUS_MODERATE -> "MODERATE"
+		PowerManager.THERMAL_STATUS_SEVERE -> "SEVERE"
+		PowerManager.THERMAL_STATUS_CRITICAL -> "CRITICAL"
+		PowerManager.THERMAL_STATUS_EMERGENCY -> "EMERGENCY"
+		PowerManager.THERMAL_STATUS_SHUTDOWN -> "SHUTDOWN"
+		else -> toString()
+	}
+
+	/** Headroom values at which LIGHT / MODERATE / SEVERE throttling begins. */
+	private data class HeadroomThresholds(val light: Float, val moderate: Float, val severe: Float) {
+
+		/**
+		 * Non-decreasing rather than strictly increasing: equal adjacent onsets collapse a band but
+		 * keep a usable scale. NaN comparisons are false, so a NaN from a misbehaving HAL fails here.
+		 */
+		fun isMonotonic() = light <= moderate && moderate <= severe
+
+		companion object {
+			val DEFAULTS = HeadroomThresholds(LIGHT_HEADROOM, MODERATE_HEADROOM, SEVERE_HEADROOM)
+		}
+	}
+
+	companion object: PerformanceManagerProvider {
+
+		override fun create(applicationContext: Context): PerformanceManager =
+			ThermalPerformanceManager(applicationContext)
+
+		private const val DELAY_IN_SECS = 30F
+
+		/** How far ahead headroom is forecast. Short windows are the accurate ones. */
+		private const val HEADROOM_FORECAST_IN_SECS = 10
+
+		/** Google's guidance: polling `getThermalHeadroom` faster than every 10s can return NaN. */
+		private const val HEADROOM_MIN_INTERVAL_IN_MILLIS = 10_000L
+
+		// Fallback headroom bands. 1.0 = onset of SEVERE is the only framework-guaranteed anchor;
+		// the two bands below it approximate a curve that is really set per device by the OEM.
+		private const val SEVERE_HEADROOM = 1F
+		private const val MODERATE_HEADROOM = 0.95F
+		private const val LIGHT_HEADROOM = 0.85F
+	}
+}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/DevicePerformanceProvider.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/DevicePerformanceProvider.kt
@@ -1,0 +1,21 @@
+package com.blinkit.droiddex.utils
+
+import android.content.Context
+import androidx.core.performance.DevicePerformance
+import androidx.core.performance.play.services.PlayServicesDevicePerformance
+
+/**
+ * Process-wide [DevicePerformance] singleton. [PlayServicesDevicePerformance] opens a DataStore
+ * file, and DataStore forbids two live instances over the same file — constructing one per manager
+ * crashes with an [IllegalStateException], so every axis must share this instance.
+ */
+internal object DevicePerformanceProvider {
+
+	@Volatile
+	private var instance: DevicePerformance? = null
+
+	fun get(applicationContext: Context): DevicePerformance =
+		instance ?: synchronized(this) {
+			instance ?: PlayServicesDevicePerformance(applicationContext.applicationContext).also { instance = it }
+		}
+}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/MemoryUtils.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/MemoryUtils.kt
@@ -9,27 +9,42 @@ internal fun getMemoryInfo(applicationContext: Context, logger: Logger): Activit
 /**
  * <a href="https://stackoverflow.com/a/9428660">Detailed Explanation</a>
  *
- * Max Memory gives the actual limit for the heap
- *
+ * Max Memory gives the actual limit for the heap of this process. NOTE: this honors android:largeHeap,
+ * so it must never be used to classify device hardware; use [getMemoryClassInMB] for that instead.
  */
 internal fun getApproxHeapLimitInMB(logger: Logger): Float =
 	convertBytesToMB(Runtime.getRuntime().maxMemory()).also { logger.logDebug("APPROXIMATE HEAP LIMIT: $it MB") }
 
-internal fun getApproxHeapRemainingInMB(logger: Logger): Float {
+/**
+ * Fraction of the process heap limit currently in use (0.0 to 1.0). Being a ratio, it stays
+ * comparable across devices and is unaffected by android:largeHeap inflating the absolute limit.
+ */
+internal fun getHeapUsedRatio(logger: Logger): Float {
 	val heapLimitInMB = getApproxHeapLimitInMB(logger)
 	val heapUsedInMB = convertBytesToMB(Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())
 
-	logger.logDebug("APPROXIMATE HEAP USED: $heapUsedInMB MB")
+	if (heapLimitInMB <= 0F) return 0F
 
-	return (heapLimitInMB - heapUsedInMB).also { logger.logDebug("APPROXIMATE HEAP REMAINING: $it MB") }
+	return (heapUsedInMB / heapLimitInMB).also { logger.logDebug("HEAP USED RATIO: $it") }
 }
+
+/**
+ * The standard per-app heap budget in MB, set by the OEM from the device's hardware profile.
+ * Unlike [getApproxHeapLimitInMB], this is NOT affected by android:largeHeap, which makes it a
+ * stable device-capability signal (same signal Telegram uses for its performance class).
+ *
+ * Returns 0 when ActivityManager is unavailable; callers must treat 0 as "unknown".
+ */
+internal fun getMemoryClassInMB(applicationContext: Context, logger: Logger): Int =
+	(getActivityManager(applicationContext, logger)?.memoryClass ?: 0).also { logger.logDebug("MEMORY CLASS: $it MB") }
+
+internal fun isLowRamDevice(applicationContext: Context, logger: Logger): Boolean =
+	(getActivityManager(applicationContext, logger)?.isLowRamDevice ?: false).also {
+		logger.logDebug("IS LOW RAM DEVICE: $it")
+	}
 
 internal fun getTotalRamInGB(applicationContext: Context, logger: Logger) =
 	convertBytesToGB(getMemoryInfo(applicationContext, logger).totalMem).also { logger.logDebug("TOTAL RAM: $it GB") }
-
-internal fun getAvailableRamInGB(applicationContext: Context, logger: Logger) = convertBytesToGB(
-	getMemoryInfo(applicationContext, logger).availMem
-).also { logger.logDebug("AVAILABLE RAM: $it GB") }
 
 private fun getActivityManager(applicationContext: Context, logger: Logger): ActivityManager? =
 	applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager ?: run {

--- a/example/src/main/kotlin/com/blinkit/droiddexexample/main/MainActivity.kt
+++ b/example/src/main/kotlin/com/blinkit/droiddexexample/main/MainActivity.kt
@@ -38,6 +38,7 @@ class MainActivity: AppCompatActivity() {
 		setupClasses(binding.network, PerformanceClass.NETWORK)
 		setupClasses(binding.storage, PerformanceClass.STORAGE)
 		setupClasses(binding.battery, PerformanceClass.BATTERY)
+		setupClasses(binding.thermal, PerformanceClass.THERMAL)
 
 		setupClasses(binding.cpuAndMemory, PerformanceClass.CPU, PerformanceClass.MEMORY)
 		setupClasses(binding.networkAndStorage, PerformanceClass.NETWORK, PerformanceClass.STORAGE)

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -96,6 +96,13 @@
 					android:layout_marginHorizontal="6dp"
 					android:layout_weight="1"/>
 
+				<com.blinkit.droiddexexample.views.ItemView
+					android:id="@+id/thermal"
+					android:layout_width="0dp"
+					android:layout_height="wrap_content"
+					android:layout_marginHorizontal="6dp"
+					android:layout_weight="1"/>
+
 			</LinearLayout>
 
 			<TextView

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ org.gradle.configuration-cache-problems=warn
 # Maven Publishing
 GROUP=com.eternal.kits
 POM_ARTIFACT_ID=droid-dex
-VERSION_NAME=3.1.0
+VERSION_NAME=4.0.0-beta01
 
 POM_NAME=Droid Dex
 POM_DESCRIPTION=Classification and Analysis of Android Device Performance


### PR DESCRIPTION
THERMAL

Adds a sixth performance class reporting how much sustained performance is left before the platform throttles for heat. The thermal status maps onto the levels and, on API 30+, is refined with getThermalHeadroom so throttling is forecast rather than observed; API 35+ devices supply their own headroom thresholds. A device with no thermal HAL pins its status to NONE and its headroom to NaN, so that combination reports UNKNOWN instead of EXCELLENT and is dropped from aggregation rather than inflating it.

CPU

Replaces the frequency-and-core-count heuristic with a microarchitecture score. CpuArchitectureScorer reads each core's MIDR from /proc/cpuinfo and weights its design by relative single-thread capability per GHz - the core design is a hardware fact an OEM cannot inflate, unlike the clocks and core counts the old logic trusted. Designs newer than the weight table score as the newest known core of their cluster role, so future SoCs tier correctly without a library update. The score is capped by platform low-end signals and cached in prefs, since every input is fixed hardware; the Media Performance Class gate stays outside the cache because Play Services resolves it asynchronously and a first-launch miss must not persist.

MEMORY

Separates the stable device tier from live pressure. Total RAM proposes the tier and the Java heap quota can only veto it, since a low quota is enforced by ART while a high one is an OEM config value that physical RAM may not back. Pressure follows the shape of Chromium's Android memory-pressure monitor: polled system state is the primary signal and the platform trim callbacks only shorten detection latency, as they are unreliable across OEMs and API levels. Downgrades apply immediately, recoveries must hold to avoid flapping on GC churn, and a SEVERE heap reading needs a confirmed streak so that not-yet collected garbage cannot trip it.

Shared

PerformanceManager now takes the application context and owns a synchronized measureAndPublish() shared by the periodic poller and event-driven re-measures, along with the premium-certification gate. DevicePerformanceProvider keeps one PlayServicesDevicePerformance per process because it opens a DataStore. MemoryUtils gains the heap-quota and low-RAM signals and drops the absolute heap-remaining reading, which android:largeHeap distorts.

Ships as 4.0.0-beta01 while the new tier logic is observed in the field.