### PR TITLE
Fix ANR: keep the trim-memory path off coroutine machinery on the main thread

### DIFF
--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/memory/MemoryPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/memory/MemoryPerformanceManager.kt
@@ -6,8 +6,6 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.os.SystemClock
-import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import com.blinkit.droiddex.constants.PerformanceClass
 import com.blinkit.droiddex.constants.PerformanceLevel
 import com.blinkit.droiddex.factory.base.PerformanceManager
@@ -17,8 +15,9 @@ import com.blinkit.droiddex.utils.getMemoryClassInMB
 import com.blinkit.droiddex.utils.getMemoryInfo
 import com.blinkit.droiddex.utils.getTotalRamInGB
 import com.blinkit.droiddex.utils.isLowRamDevice
+import com.blinkit.droiddex.utils.isProcessStarted
+import com.blinkit.droiddex.utils.pollScope
 import kotlin.concurrent.Volatile
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -219,10 +218,36 @@ internal class MemoryPerformanceManager(
 		}
 		logInfo("TRIM SIGNAL (LEVEL: $level) -> $severity")
 
-		// Storm guard: a refreshed timestamp alone doesn't need an immediate publish.
-		if (activeRawTrimPressure(now) != previousSeverity) remeasureAsync()
+		// Storm guard: a refreshed timestamp alone doesn't need an immediate publish. Backgrounded
+		// trims are stamps-only: the process is being reclaimed and the main thread is already
+		// starved, so even launching a coroutine here can stall past the ANR budget (seen in the
+		// field on FCM-woken cold starts). A backgrounded trim therefore does not publish; it leaves a
+		// hint that the next foreground measurement consumes if the process returns inside the stamp's
+		// validity window (15-30s), and drops otherwise. For a process that never foregrounds - the
+		// crash population - the hint always expires unused, i.e. background trim publishing is off;
+		// that is fine because nothing reads the level while backgrounded, and the polled state at
+		// foreground return (the primary signal for this class) decides it either way.
+		if (activeRawTrimPressure(now) != previousSeverity && isProcessInteractive()) remeasureAsync()
 	}
 
+	/**
+	 * Reads [isProcessStarted], a volatile flag kept by the shared process-lifecycle observer in
+	 * runAsyncPeriodically - so the trim path never touches ProcessLifecycleOwner/Lifecycle on the
+	 * (possibly starved) main thread, just reads a field.
+	 *
+	 * STARTED, not RESUMED: this gate only asks whether the main thread is healthy enough to launch
+	 * on, and a visible-but-unfocused process (dialog, translucent activity) is. The poll loop's own
+	 * RESUMED gate answers a different question - whether the level is worth refreshing at all. The
+	 * flag defaults false until the observer registers, so an early trim is treated as backgrounded
+	 * (stamp-only) - fail-safe, and the unconditional first poll seeds the level regardless.
+	 */
+	private fun isProcessInteractive(): Boolean = isProcessStarted
+
+	/**
+	 * Routed through [onTrimMemory] as CRITICAL, so a backgrounded onLowMemory is stamps-only too -
+	 * deliberate: it is the most severe signal, which makes launching on the starved main thread the
+	 * riskiest, and the stamp is still consumed at foreground return like any other trim.
+	 */
 	@Suppress("DEPRECATION")
 	override fun onLowMemory() = onTrimMemory(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
 
@@ -279,15 +304,17 @@ internal class MemoryPerformanceManager(
 		stampMs != 0L && nowMs - stampMs <= validityMs
 
 	/**
-	 * Publishes without waiting for the next poll tick, and works while polling is paused in the
-	 * background. Immediate calls are coalesced so trim bursts cannot queue unbounded measures.
+	 * Publishes without waiting for the next poll tick. Immediate calls are coalesced so trim
+	 * bursts cannot queue unbounded measures. Runs on the shared [pollScope] rather than the process
+	 * lifecycleScope: the lifecycle-scope lookup and launch walk enough code on the caller thread to
+	 * ANR when this fires from a trim callback on a memory-starved device.
 	 */
 	private fun remeasureAsync(delayInMs: Long = 0L) {
 		if (delayInMs == 0L) {
 			if (hasPendingImmediateRemeasure) return
 			hasPendingImmediateRemeasure = true
 		}
-		ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.IO) {
+		pollScope.launch {
 			if (delayInMs > 0L) delay(delayInMs) else hasPendingImmediateRemeasure = false
 			measureAndPublish()
 		}

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
@@ -1,16 +1,20 @@
 package com.blinkit.droiddex.utils
 
-import androidx.lifecycle.Lifecycle
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.blinkit.droiddex.constants.PerformanceLevel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -52,14 +56,53 @@ internal fun getPerformanceLevelLdWithWeights(
 	}
 }
 
-internal fun runAsyncPeriodically(block: () -> Unit, delayInSecs: Float) = with(ProcessLifecycleOwner.get()) {
-	block()
-	lifecycleScope.launch {
-		repeatOnLifecycle(Lifecycle.State.RESUMED) {
-			while (true) {
-				withContext(Dispatchers.IO) { block() }
-				delay((delayInSecs * 1000).toLong())
+/** Process-lifetime worker for every periodic measurement; deliberately never cancelled. */
+private val pollScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+/** True while the process is RESUMED; written only by [registerForegroundTrackerOnce]'s observer. */
+private val isProcessResumed = MutableStateFlow(false)
+
+/**
+ * One observer for all pollers, replacing a repeatOnLifecycle per manager. Always posted, never run
+ * inline: init reaches here on the caller thread inside Application.onCreate, and the
+ * ProcessLifecycleOwner/Lifecycle class-init it would pull in there is exactly what the startup ANR
+ * stacks are parked in. addObserver replays the lifecycle up to the current state, so registering a
+ * message later still seeds the flow correctly.
+ */
+private val registerForegroundTrackerOnce: Unit by lazy {
+	Handler(Looper.getMainLooper()).post {
+		ProcessLifecycleOwner.get().lifecycle.addObserver(object: DefaultLifecycleObserver {
+			override fun onResume(owner: LifecycleOwner) {
+				isProcessResumed.value = true
 			}
+
+			override fun onPause(owner: LifecycleOwner) {
+				isProcessResumed.value = false
+			}
+		})
+	}
+	Unit
+}
+
+/**
+ * Runs [block] once right away (whatever the process state, so a background start still seeds a
+ * level), then keeps re-running it every [delayInSecs] while the process is RESUMED. In the
+ * background the loop parks at the gate; a resume from there measures at once, but a resume landing
+ * mid-delay waits the remainder out - one poll period of staleness at worst.
+ *
+ * Everything - including the first measurement - runs on [pollScope], never on the caller thread:
+ * the previous shape measured synchronously in the caller (seconds of Application.onCreate work on
+ * low-tier devices) and set up its polling via the process lifecycleScope, putting per-manager
+ * coroutine machinery on the main thread during startup - both showed up as startup ANRs.
+ */
+internal fun runAsyncPeriodically(block: () -> Unit, delayInSecs: Float) {
+	registerForegroundTrackerOnce
+	pollScope.launch {
+		block()
+		while (true) {
+			isProcessResumed.first { it }
+			block()
+			delay((delayInSecs * 1000).toLong())
 		}
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
@@ -68,6 +68,12 @@ private val isProcessResumed = MutableStateFlow(false)
  * ProcessLifecycleOwner/Lifecycle class-init it would pull in there is exactly what the startup ANR
  * stacks are parked in. addObserver replays the lifecycle up to the current state, so registering a
  * message later still seeds the flow correctly.
+ *
+ * The post lands on the main thread, so during a stalled startup (the stall this fix targets) the
+ * observer registers only after onCreate drains. Until then isProcessResumed stays false and every
+ * poller parks after its seed measurement, so the first foreground re-measure can land well after
+ * delayInSecs rather than one interval in. Self-healing, not a defect: the parked loops unpark on
+ * the next RESUMED.
  */
 private val registerForegroundTrackerOnce: Unit by lazy {
 	Handler(Looper.getMainLooper()).post {
@@ -84,6 +90,11 @@ private val registerForegroundTrackerOnce: Unit by lazy {
 	Unit
 }
 
+/** Forces [registerForegroundTrackerOnce]; a bare property read at the call site reads as dead code. */
+private fun ensureForegroundTrackerRegistered() {
+	registerForegroundTrackerOnce
+}
+
 /**
  * Runs [block] once right away (whatever the process state, so a background start still seeds a
  * level), then keeps re-running it every [delayInSecs] while the process is RESUMED. In the
@@ -96,7 +107,7 @@ private val registerForegroundTrackerOnce: Unit by lazy {
  * coroutine machinery on the main thread during startup - both showed up as startup ANRs.
  */
 internal fun runAsyncPeriodically(block: () -> Unit, delayInSecs: Float) {
-	registerForegroundTrackerOnce
+	ensureForegroundTrackerRegistered()
 	pollScope.launch {
 		block()
 		while (true) {

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -56,18 +57,32 @@ internal fun getPerformanceLevelLdWithWeights(
 	}
 }
 
-/** Process-lifetime worker for every periodic measurement; deliberately never cancelled. */
-private val pollScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+/**
+ * Process-lifetime worker for every periodic measurement and every event-driven remeasure (e.g. the
+ * memory manager's trim fast path); deliberately never cancelled.
+ */
+internal val pollScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
 /** True while the process is RESUMED; written only by [registerForegroundTrackerOnce]'s observer. */
 private val isProcessResumed = MutableStateFlow(false)
+
+/**
+ * True while the process is at least STARTED (visible). Written only by [registerForegroundTrackerOnce]'s
+ * observer; a plain volatile, not a flow, because the only reader ([runAsyncPeriodically]'s consumers'
+ * trim gate) reads it synchronously and never suspends on it. Defaults false until the posted observer
+ * registers and replays the lifecycle - fail-safe for the gate, which then treats an early trim as
+ * backgrounded (stamp-only).
+ */
+@Volatile
+internal var isProcessStarted = false
+	private set
 
 /**
  * One observer for all pollers, replacing a repeatOnLifecycle per manager. Always posted, never run
  * inline: init reaches here on the caller thread inside Application.onCreate, and the
  * ProcessLifecycleOwner/Lifecycle class-init it would pull in there is exactly what the startup ANR
  * stacks are parked in. addObserver replays the lifecycle up to the current state, so registering a
- * message later still seeds the flow correctly.
+ * message later still seeds both the flow and [isProcessStarted] correctly.
  *
  * The post lands on the main thread, so during a stalled startup (the stall this fix targets) the
  * observer registers only after onCreate drains. Until then isProcessResumed stays false and every
@@ -78,6 +93,14 @@ private val isProcessResumed = MutableStateFlow(false)
 private val registerForegroundTrackerOnce: Unit by lazy {
 	Handler(Looper.getMainLooper()).post {
 		ProcessLifecycleOwner.get().lifecycle.addObserver(object: DefaultLifecycleObserver {
+			override fun onStart(owner: LifecycleOwner) {
+				isProcessStarted = true
+			}
+
+			override fun onStop(owner: LifecycleOwner) {
+				isProcessStarted = false
+			}
+
 			override fun onResume(owner: LifecycleOwner) {
 				isProcessResumed.value = true
 			}


### PR DESCRIPTION
# Fix ANR: keep the trim-memory path off coroutine machinery on the main thread

> **Stacked on #16** (`fix/anr-periodic-poll-main-thread`). This builds on #16's shared `pollScope` and its one process-lifecycle observer, so **until #16 merges the diff below also contains #16's changes**. Review #16 first; once it lands this rebases onto `master` to a focused ~+61/−11 diff. Its own contribution is the trim-path fix in `MemoryPerformanceManager` plus the `isProcessStarted` addition to #16's observer.

## Problem

An ANR — *"triggered by slow operations in main thread"*, blamed on `MemoryPerformanceManager.remeasureAsync` — first seen in the app release that shipped droid-dex `v4.0.0-beta01`.

Anonymized main-thread trace (app frame redacted, framework noise trimmed, pre-fix line numbers):

```
ANR "triggered by slow operations in main thread" — process state: BACKGROUND

  at com.blinkit.droiddex.memory.MemoryPerformanceManager.remeasureAsync (MemoryPerformanceManager.kt:290)
  at com.blinkit.droiddex.memory.MemoryPerformanceManager.remeasureAsync$default (MemoryPerformanceManager.kt:285)
  at com.blinkit.droiddex.memory.MemoryPerformanceManager.onTrimMemory (MemoryPerformanceManager.kt:223)
  at android.content.ComponentCallbacksController.dispatchTrimMemory (ComponentCallbacksController.java:107)
  at android.app.Application.onTrimMemory (Application.java:283)
  at <application>.onTrimMemory                                    # app Application subclass — redacted
  at android.app.ActivityThread.handleTrimMemory (ActivityThread.java:6620)
  at android.app.ActivityThread$ApplicationThread.lambda$scheduleTrimMemory$0 (ActivityThread.java:1732)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:233)
  ...
```

One sample was parked as deep as `AtomicReference.get` inside `LifecycleKt.getCoroutineScope` — the `lifecycleScope` lookup itself.

All sampled events share one shape:

- **background cold start woken by an FCM push** (`processState: BACKGROUND`, low/mid-tier devices, Android 11–13),
- OS delivers `onTrimMemory` right after `Application.onCreate`, at `TRIM_MEMORY_RUNNING_*` levels (10/15 in this sample),
- main thread ANRs inside `remeasureAsync` at `ProcessLifecycleOwner.get().lifecycleScope.launch(Dispatchers.IO)`.

Anonymized log tail from one sample (ids / tokens / deeplinks stripped, times relative to `ON_CREATE_START`):

```
+0.00s   APPLICATION | ON_CREATE_START
+6.52s   DROID-DEX: MEMORY | DEVICE TIER: AVERAGE (RAM TIER: AVERAGE, HEAP QUOTA CEILING: EXCELLENT)
+6.53s   DROID-DEX: MEMORY | PERFORMANCE LEVEL: AVERAGE
+9.16s   APPLICATION | ON_CREATE_END
+9.26s   DROID-DEX: MEMORY | TRIM SIGNAL (LEVEL: 15) -> CRITICAL    # trim fires right after onCreate
+9.27s   DROID-DEX: MEMORY | PERFORMANCE LEVEL: LOW                 # publish driven from the trim path, on main
+9.29s   DROID-DEX: MEMORY | TRIM SIGNAL (LEVEL: 10) -> MODERATE
+9.29s   DROID-DEX: MEMORY | TRIM SIGNAL (LEVEL: 15) -> CRITICAL
+9.56s   FCM: push received                                        # process was FCM-woken
```

At the moment a trim callback fires, the device is memory-starved (kswapd/zram churn, GC-for-alloc pauses, background cpuset). Any non-trivial work on the main thread — the lifecycle-scope lookup, coroutine construction, IO dispatch — can stall past the ANR budget. The trim path did all of it on main.

## Fix

- `onTrimMemory` while **backgrounded** now only stamps the volatile trim timestamps (allocation-free) and does not launch anything. A backgrounded trim therefore no longer publishes — it leaves a hint the next foreground measurement consumes if the process returns inside the stamp's validity window (15–30s, unchanged), and drops otherwise. For a process that never foregrounds — the crash population — the hint always expires unused, i.e. background trim publishing is effectively off; that is fine, because nothing reads the level while backgrounded and the polled state at foreground return (the primary signal for this class on every API level) decides it either way. `onLowMemory` routes through `onTrimMemory` as CRITICAL and is gated the same way — deliberate: it is the most severe signal, so launching on the starved main thread is riskiest there.
- Foreground immediate remeasures and the SEVERE-confirmation delayed remeasure now run on **#16's shared process-lifetime `pollScope`** (`SupervisorJob() + Dispatchers.IO`), instead of the process `lifecycleScope`, so the trim path never builds lifecycle/coroutine machinery on the caller thread. The `hasPendingImmediateRemeasure` coalescing semantics are unchanged.
- The foreground gate is a plain read of a shared `@Volatile isProcessStarted`, maintained by #16's process-lifecycle observer (extended here with `onStart`/`onStop`) — so the trim path never touches `ProcessLifecycleOwner`/`Lifecycle` on the (possibly starved) main thread, just reads a field. It gates on **STARTED, not RESUMED**: the question is only whether the main thread is healthy enough to launch on, and a visible-but-unfocused process (dialog, translucent activity) is. The poll loop's own RESUMED gate answers a different question — whether the level is worth refreshing at all. The flag defaults `false` until the observer registers, so an early trim is treated as backgrounded (stamp-only) — fail-safe, and #16's unconditional first poll seeds the level regardless. The gate deliberately does **not** use the trim `level`: FCM-woken background processes receive `TRIM_MEMORY_RUNNING_*` levels (seen in the field), so trim level is not a foreground proxy.

## Behavior change

A backgrounded process no longer publishes an immediate level downgrade on trim. If it returns to the foreground inside the validity window the downgrade lands on that measurement; if it stays backgrounded past the window, the trim signal is dropped and the level is decided by the polled state at foreground return. Foreground trim behavior is unchanged.

## Verification

`./gradlew droid-dex:assembleRelease` — compiles clean (explicitApi on; one pre-existing `OVERRIDE_DEPRECATION` warning on `onLowMemory`, untouched here). No unit tests exist in this repo per its conventions; the `:example` runtime check was **not** run.
