### PR TITLE
Fix ANR: run periodic measurements fully off the caller/main thread

### DIFF
--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
@@ -1,16 +1,20 @@
 package com.blinkit.droiddex.utils
 
-import androidx.lifecycle.Lifecycle
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ProcessLifecycleOwner
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.blinkit.droiddex.constants.PerformanceLevel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.math.ceil
 import kotlin.math.roundToInt
 
@@ -52,14 +56,53 @@ internal fun getPerformanceLevelLdWithWeights(
 	}
 }
 
-internal fun runAsyncPeriodically(block: () -> Unit, delayInSecs: Float) = with(ProcessLifecycleOwner.get()) {
-	block()
-	lifecycleScope.launch {
-		repeatOnLifecycle(Lifecycle.State.RESUMED) {
-			while (true) {
-				withContext(Dispatchers.IO) { block() }
-				delay((delayInSecs * 1000).toLong())
+/** Process-lifetime worker for every periodic measurement; deliberately never cancelled. */
+private val pollScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+/** True while the process is RESUMED; written only by [registerForegroundTrackerOnce]'s observer. */
+private val isProcessResumed = MutableStateFlow(false)
+
+/**
+ * One observer for all pollers, replacing a repeatOnLifecycle per manager. Always posted, never run
+ * inline: init reaches here on the caller thread inside Application.onCreate, and the
+ * ProcessLifecycleOwner/Lifecycle class-init it would pull in there is exactly what the startup ANR
+ * stacks are parked in. addObserver replays the lifecycle up to the current state, so registering a
+ * message later still seeds the flow correctly.
+ */
+private val registerForegroundTrackerOnce: Unit by lazy {
+	Handler(Looper.getMainLooper()).post {
+		ProcessLifecycleOwner.get().lifecycle.addObserver(object: DefaultLifecycleObserver {
+			override fun onResume(owner: LifecycleOwner) {
+				isProcessResumed.value = true
 			}
+
+			override fun onPause(owner: LifecycleOwner) {
+				isProcessResumed.value = false
+			}
+		})
+	}
+	Unit
+}
+
+/**
+ * Runs [block] once right away (whatever the process state, so a background start still seeds a
+ * level), then keeps re-running it every [delayInSecs] while the process is RESUMED. In the
+ * background the loop parks at the gate; a resume from there measures at once, but a resume landing
+ * mid-delay waits the remainder out - one poll period of staleness at worst.
+ *
+ * Everything - including the first measurement - runs on [pollScope], never on the caller thread:
+ * the previous shape measured synchronously in the caller (seconds of Application.onCreate work on
+ * low-tier devices) and set up its polling via the process lifecycleScope, putting per-manager
+ * coroutine machinery on the main thread during startup - both showed up as startup ANRs.
+ */
+internal fun runAsyncPeriodically(block: () -> Unit, delayInSecs: Float) {
+	registerForegroundTrackerOnce
+	pollScope.launch {
+		block()
+		while (true) {
+			isProcessResumed.first { it }
+			block()
+			delay((delayInSecs * 1000).toLong())
 		}
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/utils/Utils.kt
@@ -68,6 +68,12 @@ private val isProcessResumed = MutableStateFlow(false)
  * ProcessLifecycleOwner/Lifecycle class-init it would pull in there is exactly what the startup ANR
  * stacks are parked in. addObserver replays the lifecycle up to the current state, so registering a
  * message later still seeds the flow correctly.
+ *
+ * The post lands on the main thread, so during a stalled startup (the stall this fix targets) the
+ * observer registers only after onCreate drains. Until then isProcessResumed stays false and every
+ * poller parks after its seed measurement, so the first foreground re-measure can land well after
+ * delayInSecs rather than one interval in. Self-healing, not a defect: the parked loops unpark on
+ * the next RESUMED.
  */
 private val registerForegroundTrackerOnce: Unit by lazy {
 	Handler(Looper.getMainLooper()).post {
@@ -84,6 +90,11 @@ private val registerForegroundTrackerOnce: Unit by lazy {
 	Unit
 }
 
+/** Forces [registerForegroundTrackerOnce]; a bare property read at the call site reads as dead code. */
+private fun ensureForegroundTrackerRegistered() {
+	registerForegroundTrackerOnce
+}
+
 /**
  * Runs [block] once right away (whatever the process state, so a background start still seeds a
  * level), then keeps re-running it every [delayInSecs] while the process is RESUMED. In the
@@ -96,7 +107,7 @@ private val registerForegroundTrackerOnce: Unit by lazy {
  * coroutine machinery on the main thread during startup - both showed up as startup ANRs.
  */
 internal fun runAsyncPeriodically(block: () -> Unit, delayInSecs: Float) {
-	registerForegroundTrackerOnce
+	ensureForegroundTrackerRegistered()
 	pollScope.launch {
 		block()
 		while (true) {


### PR DESCRIPTION
# Fix ANR: run periodic measurements fully off the caller/main thread

## Problem

Long-standing startup ANR concentrated in `droid-dex`'s periodic-measurement setup, seen as a large ANR cluster in our internal crash reporting (order ~10k ANR events / ~8k affected users over a 15-day window, first observed several releases ago and still shipping).

It groups on `UtilsKt$runAsyncPeriodically$1$1.invokeSuspend` (`Utils.kt:58`). The sampled main thread is a starved background cold start resuming the poll-setup coroutine on `Dispatchers.Main.immediate`, stuck in `Lifecycle` class-init:

```text
# Reconstructed from the crash signature and redacted: host-app frames removed,
# only droid-dex + AndroidX/framework frames shown.

"main" tid=1  (background cold start, resuming poll-setup coroutine on the main dispatcher)
  at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.kt)
  at androidx.lifecycle.RepeatOnLifecycleKt.repeatOnLifecycle(RepeatOnLifecycle.kt)
  at com.blinkit.droiddex.utils.UtilsKt$runAsyncPeriodically$1$1.invokeSuspend(Utils.kt:58)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt)
  at android.os.Handler.handleCallback(Handler.java)
  at android.os.Looper.loop(Looper.java)
  at android.app.ActivityThread.main(ActivityThread.java)
```

`runAsyncPeriodically` put startup work on the wrong threads in two ways:

1. The **first measurement ran synchronously on the `DroidDex.init` caller thread**. The host app calls `DroidDex.init` from its `Application.onCreate`, which constructs all six managers, so procfs reads, a SharedPreferences disk load, `ActivityManager`/`PowerManager` binder calls and `StatFs` disk I/O all run serially on that thread. Field logs show the six DROID-DEX log lines landing 1.5–4.5 s after `ON_CREATE_START` on low-tier devices.
2. Each of the six managers launched its polling coroutine on the **main dispatcher** (`ProcessLifecycleOwner.lifecycleScope` = `Dispatchers.Main.immediate`), and the sampled ANR stacks show the main thread executing the `repeatOnLifecycle` setup (`Utils.kt:58`) during starved background cold starts.

## Fix

`runAsyncPeriodically` now runs everything on one shared process-lifetime `CoroutineScope(SupervisorJob() + Dispatchers.IO)`:

- the first measurement included — off the caller thread, and unconditionally, so a background (FCM) start still seeds a level;
- the poll loop parks on a `MutableStateFlow<Boolean>` fed by **one shared `ProcessLifecycleOwner` observer** instead of a `repeatOnLifecycle` per manager. That observer is **always registered via a post to the main thread, never inline**: `init` reaches this code on the caller thread inside `Application.onCreate`, and the `ProcessLifecycleOwner`/`Lifecycle` class-init it would pull in there is exactly what the ANR stacks are parked in. `addObserver` replays the lifecycle up to the current state, so registering a message later still seeds the flow correctly.

## Behavior changes (deliberate, called out for review)

- `DroidDex.getPerformanceLevel()` called synchronously right after `init()` can now return `UNKNOWN` until the first async measurement lands (typically well under a second). We audited the downstream consumers in the host app: the synchronous ones go through a wrapper that already maps `UNKNOWN → null`, and every call site does a null-safe `== LOW`-style check at screen/network time, not in `onCreate`. The LiveData surface always started at `UNKNOWN`, so observers are unaffected.
- Polling still pauses while backgrounded, but the resume semantics differ slightly. Previously `repeatOnLifecycle` cancelled the loop mid-delay, so every foreground return re-measured instantly. Now a resume from a parked loop measures at once, while a resume landing mid-delay waits the remainder out — worst case one poll period (10 s for memory, more for slower axes). The next tick then measures with fresh foreground state.

## Verification

`./gradlew droid-dex:assembleRelease` — compiles clean (explicitApi on). No unit tests exist in this repo per its conventions; the `:example` runtime check was **not** run.
