### PR TITLE
feat(cpu): age old-flagship silicon out of the EXCELLENT tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,3 @@ implementation("com.blinkit.kits:droid-dex:<<your_version>>")
 ```
 
 </details>
-
-## Releasing
-
-Maintainer checklist for each release:
-
-- **Bump `LIBRARY_BUILD_YEAR`** in `CpuPerformanceManager` to the release year. It floors the CPU old-flagship aging clock: a stale value never misclassifies, but once the library is more than `MAX_LIBRARY_AGE_YEARS` old it silently stops aging new flagships out of `EXCELLENT`.

--- a/README.md
+++ b/README.md
@@ -167,3 +167,9 @@ implementation("com.blinkit.kits:droid-dex:<<your_version>>")
 ```
 
 </details>
+
+## Releasing
+
+Maintainer checklist for each release:
+
+- **Bump `LIBRARY_BUILD_YEAR`** in `CpuPerformanceManager` to the release year. It floors the CPU old-flagship aging clock: a stale value never misclassifies, but once the library is more than `MAX_LIBRARY_AGE_YEARS` old it silently stops aging new flagships out of `EXCELLENT`.

--- a/droid-dex/build.gradle.kts
+++ b/droid-dex/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
 import java.net.URI
+import java.time.Year
 
 plugins {
 	alias(libs.plugins.android.library)
@@ -43,6 +44,8 @@ android {
 		targetSdk = libs.versions.sdk.target.get().toInt()
 
 		consumerProguardFiles("consumer-rules.pro")
+
+		buildConfigField("int", "LIBRARY_BUILD_YEAR", "${Year.now().value}")
 	}
 
 	buildFeatures { buildConfig = true }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
@@ -272,8 +272,9 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		private const val KEY_SCORED_GENERATION_YEAR = "scored_generation_year"
 		private const val NO_GENERATION_YEAR = 0
 
-		// Bump when the scoring algorithm, core-weight table, tier thresholds, age-decay logic or
-		// hardware cap change, so tiers cached by older logic are recomputed.
-		private const val CACHE_SCHEMA_VERSION = 3
+		// Bump (once per release) when the scoring algorithm, core-weight table, tier thresholds,
+		// age-decay logic or hardware cap change, so tiers cached by older shipped logic are recomputed.
+		// Last shipped value: 1 (v4.0.0-beta01); this release changes the schema once, so 2.
+		private const val CACHE_SCHEMA_VERSION = 2
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
@@ -2,6 +2,7 @@ package com.blinkit.droiddex.cpu
 
 import android.content.Context
 import android.os.Build
+import com.blinkit.droiddex.BuildConfig
 import com.blinkit.droiddex.constants.PerformanceClass
 import com.blinkit.droiddex.constants.PerformanceLevel
 import com.blinkit.droiddex.cpu.utils.CpuArchitectureScorer
@@ -225,9 +226,9 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		// currentYear() clamps it to a plausible window: below the build year is impossible, and a
 		// library more than MAX_LIBRARY_AGE_YEARS stale stops dating new cores anyway. An out-of-window
 		// read falls to LIBRARY_BUILD_YEAR - the least-aging plausible value - so a bad clock never
-		// wrongly demotes. Bump LIBRARY_BUILD_YEAR each release (a stale value only under-ages, which is
-		// the fail-safe direction).
-		private const val LIBRARY_BUILD_YEAR = 2026
+		// wrongly demotes. LIBRARY_BUILD_YEAR is stamped at build time (BuildConfig), so it needs no
+		// manual bump; even a stale value only under-ages, which is the fail-safe direction.
+		private val LIBRARY_BUILD_YEAR = BuildConfig.LIBRARY_BUILD_YEAR
 		private const val MAX_LIBRARY_AGE_YEARS = 3
 
 		// Device-ship year of the flagship generation that first ships with each Media Performance Class,

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
@@ -21,9 +21,9 @@ import java.util.Calendar
  * EXCELLENT tier is capped to HIGH once its flagship silicon generation is a few years old
  * ([capOldFlagship]), so "EXCELLENT can handle every feature" keeps describing current flagships and
  * not once-flagship hardware; a Media-Performance-Class certification short-circuits the score while it
- * is current and defers back to it once aged out ([premiumCertifiedTier]); and platform low-end signals
- * ([measureHardwareCap]) cap the result so a fast SoC paired with starved memory never reports a
- * rich-experience tier.
+ * is current and, once aged out, caps a chip the score cannot date (Oryon) while deferring to the score
+ * for one it can ([premiumCertifiedTier]); and platform low-end signals ([measureHardwareCap]) cap the
+ * result so a fast SoC paired with starved memory never reports a rich-experience tier.
  *
  * The hardware inputs are fixed, so they are measured once, persisted and served from cache on later
  * launches. Because the score now ages with the calendar, the cache is keyed by both
@@ -46,21 +46,23 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	override fun getDelayInSecs() = DELAY_IN_SECS
 
 	override fun measurePerformanceLevel(): PerformanceLevel {
-		val (cachedScoredTier, cachedHardwareCap) = readCachedHardwareTiers() ?: return computeDeviceTier()
-		return applyPremiumGate(cachedScoredTier, cachedHardwareCap).also { logInfo("DEVICE TIER (CACHED): $it") }
+		val (cachedScoredTier, cachedScoredYear, cachedHardwareCap) = readCachedHardwareTiers() ?: return computeDeviceTier()
+		return applyPremiumGate(cachedScoredTier, cachedScoredYear, cachedHardwareCap)
+			.also { logInfo("DEVICE TIER (CACHED): $it") }
 	}
 
 	private fun computeDeviceTier(): PerformanceLevel {
 		val hardwareCap = measureHardwareCap()
 
-		// No MIDR info (x86 emulator, restricted procfs): no score to defer to, so the premium gate
-		// still applies directly; the procfs read may succeed on a later launch, so nothing is cached.
-		val scoredTier = measureMicroarchitectureTier() ?: return (
-			if (isPremiumCertified()) minLevel(hardwareCap, premiumCertifiedTier()) else hardwareCap
-			).also { logInfo("NO MICROARCHITECTURE INFO, DEVICE TIER (NOT CACHED): $it") }
+		// No MIDR info (x86 emulator, restricted procfs): an undatable chip (null year), so the premium
+		// gate ages it via the certification alone. hardwareCap stands in for the absent scoredTier (a
+		// minLevel no-op). The procfs read may succeed later, so nothing is cached.
+		val (scoredTier, scoredYear) = measureMicroarchitectureTier()
+			?: return applyPremiumGate(hardwareCap, null, hardwareCap)
+				.also { logInfo("NO MICROARCHITECTURE INFO, DEVICE TIER (NOT CACHED): $it") }
 
-		writeCachedHardwareTiers(scoredTier, hardwareCap)
-		return applyPremiumGate(scoredTier, hardwareCap).also { logInfo("DEVICE TIER: $it") }
+		writeCachedHardwareTiers(scoredTier, scoredYear, hardwareCap)
+		return applyPremiumGate(scoredTier, scoredYear, hardwareCap).also { logInfo("DEVICE TIER: $it") }
 	}
 
 	/**
@@ -68,19 +70,30 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	 * asynchronously, so a first-ever launch can read the framework default and miss a real
 	 * certification - caching that would make the miss permanent. A current certification short-circuits
 	 * the score to the hardware cap (it vouches for the SoC, not the memory). Once aged out
-	 * ([premiumCertifiedTier]) it no longer implies a current flagship, but a class is an OEM-declared
-	 * floor a current flagship can under-declare, so the tier defers to the score rather than hard-capping.
+	 * ([premiumCertifiedTier]) it caps the tier, but only for a chip the score could not date (null
+	 * [scoredGenerationYear] - Oryon, uncatalogued, or no-MIDR): a datable chip has already self-aged
+	 * through [capOldFlagship], so it defers to the score, and a current flagship that merely
+	 * under-declares its class is not demoted.
 	 */
-	private fun applyPremiumGate(scoredTier: PerformanceLevel, hardwareCap: PerformanceLevel): PerformanceLevel =
-		if (isPremiumCertified() && premiumCertifiedTier() == PerformanceLevel.EXCELLENT) hardwareCap
-		else minLevel(scoredTier, hardwareCap)
+	private fun applyPremiumGate(
+		scoredTier: PerformanceLevel, scoredGenerationYear: Int?, hardwareCap: PerformanceLevel
+	): PerformanceLevel {
+		if (!isPremiumCertified()) return minLevel(scoredTier, hardwareCap)
+		val certifiedTier = premiumCertifiedTier()
+		if (certifiedTier == PerformanceLevel.EXCELLENT) return hardwareCap
+		// Certification has aged out. A datable chip trusts the score (already self-aged); an undatable
+		// one (null year) has no scored age, so the aged class caps it.
+		return if (scoredGenerationYear != null) minLevel(scoredTier, hardwareCap)
+		else minLevel(minLevel(scoredTier, hardwareCap), certifiedTier)
+	}
 
 	/**
 	 * Whether the certification is still current or has aged out. Keyed by the device-ship year the
 	 * Media Performance Class maps to ([FLAGSHIP_SHIP_YEAR_BY_SDK_INT]) on the same convention as the
 	 * scored path, so both paths age alike. An unrecognised (newer-than-table) class yields no year and
-	 * stays EXCELLENT - a just-released device must not be aged. This only decides whether to keep the
-	 * certification short-circuit; an aged-out class defers to the score (see [applyPremiumGate]).
+	 * stays EXCELLENT - a just-released device must not be aged. This only decides whether the
+	 * certification short-circuit still holds; an aged-out class then caps an undatable chip and defers
+	 * to the score for a datable one (see [applyPremiumGate]).
 	 */
 	private fun premiumCertifiedTier(): PerformanceLevel {
 		val mediaPerformanceClass = DevicePerformanceProvider.get(applicationContext).mediaPerformanceClass
@@ -89,12 +102,13 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	}
 
 	private fun currentYear(): Int = Calendar.getInstance().get(Calendar.YEAR)
+		.takeIf { it in LIBRARY_BUILD_YEAR..LIBRARY_BUILD_YEAR + MAX_LIBRARY_AGE_YEARS } ?: LIBRARY_BUILD_YEAR
 
 	/** A silicon generation or certification is "old flagship" once it is [OLD_FLAGSHIP_MIN_AGE_YEARS]+ years old. */
 	private fun isOldFlagship(generationYear: Int): Boolean =
 		currentYear() - generationYear >= OLD_FLAGSHIP_MIN_AGE_YEARS
 
-	private fun measureMicroarchitectureTier(): PerformanceLevel? {
+	private fun measureMicroarchitectureTier(): Pair<PerformanceLevel, Int?>? {
 		val (score, flagshipGenerationYear) = architectureScorer.computeScore(cpuInfoManager.coreMaxFreqsInKHz)
 			?: return null
 		val scoredTier = when {
@@ -103,8 +117,8 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 			score < HIGH_TIER_MAX_SCORE -> PerformanceLevel.HIGH
 			else -> PerformanceLevel.EXCELLENT
 		}
-		return capOldFlagship(scoredTier, flagshipGenerationYear).also {
-			logInfo("MICROARCHITECTURE SCORE: $score (flagship generation $flagshipGenerationYear) -> $it")
+		return (capOldFlagship(scoredTier, flagshipGenerationYear) to flagshipGenerationYear).also {
+			logInfo("MICROARCHITECTURE SCORE: $score (flagship generation $flagshipGenerationYear) -> ${it.first}")
 		}
 	}
 
@@ -141,16 +155,20 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	}
 
 	/**
-	 * Both halves must be present to be usable, so a partial write is treated as no cache at all. The
-	 * year is part of the validity check because the scored tier is age-decayed: a tier cached last
-	 * year may need to drop this year, so a stale-year cache is ignored and recomputed.
+	 * Both tier levels must be present to be usable, so a partial write is treated as no cache at all;
+	 * [KEY_SCORED_GENERATION_YEAR] is exempt - 0/absent legitimately means an undatable chip, read as
+	 * null rather than guarded on. The calendar year is part of the validity check because the scored
+	 * tier is age-decayed: a tier cached last year may need to drop this year, so a stale-year cache is
+	 * ignored and recomputed.
 	 */
-	private fun readCachedHardwareTiers(): Pair<PerformanceLevel, PerformanceLevel>? = try {
+	private fun readCachedHardwareTiers(): Triple<PerformanceLevel, Int?, PerformanceLevel>? = try {
 		if (cachePrefs.getInt(KEY_CACHE_SCHEMA_VERSION, 0) == CACHE_SCHEMA_VERSION &&
 			cachePrefs.getInt(KEY_CACHE_YEAR, 0) == currentYear()) {
 			val scoredTier = readCachedLevel(KEY_SCORED_TIER_LEVEL)
 			val hardwareCap = readCachedLevel(KEY_HARDWARE_CAP_LEVEL)
-			if (scoredTier != null && hardwareCap != null) scoredTier to hardwareCap else null
+			val scoredYear = cachePrefs.getInt(KEY_SCORED_GENERATION_YEAR, NO_GENERATION_YEAR)
+				.takeIf { it != NO_GENERATION_YEAR }
+			if (scoredTier != null && hardwareCap != null) Triple(scoredTier, scoredYear, hardwareCap) else null
 		} else null
 	} catch (e: Exception) {
 		logError(e)
@@ -161,12 +179,13 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		PerformanceLevel.getPerformanceLevel(cachePrefs.getInt(key, PerformanceLevel.UNKNOWN.level))
 			.takeIf { it != PerformanceLevel.UNKNOWN }
 
-	private fun writeCachedHardwareTiers(scoredTier: PerformanceLevel, hardwareCap: PerformanceLevel) {
+	private fun writeCachedHardwareTiers(scoredTier: PerformanceLevel, scoredYear: Int?, hardwareCap: PerformanceLevel) {
 		try {
 			cachePrefs.edit()
 				.putInt(KEY_CACHE_SCHEMA_VERSION, CACHE_SCHEMA_VERSION)
 				.putInt(KEY_CACHE_YEAR, currentYear())
 				.putInt(KEY_SCORED_TIER_LEVEL, scoredTier.level)
+				.putInt(KEY_SCORED_GENERATION_YEAR, scoredYear ?: NO_GENERATION_YEAR)
 				.putInt(KEY_HARDWARE_CAP_LEVEL, hardwareCap.level)
 				.apply()
 		} catch (e: Exception) {
@@ -202,8 +221,17 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		// silicon generation (scored path) or certification (MPC path) is this many years old.
 		private const val OLD_FLAGSHIP_MIN_AGE_YEARS = 3
 
+		// The device clock is untrusted (user-settable) but drives aging and the year-keyed cache, so
+		// currentYear() clamps it to a plausible window: below the build year is impossible, and a
+		// library more than MAX_LIBRARY_AGE_YEARS stale stops dating new cores anyway. An out-of-window
+		// read falls to LIBRARY_BUILD_YEAR - the least-aging plausible value - so a bad clock never
+		// wrongly demotes. Bump LIBRARY_BUILD_YEAR each release (a stale value only under-ages, which is
+		// the fail-safe direction).
+		private const val LIBRARY_BUILD_YEAR = 2026
+		private const val MAX_LIBRARY_AGE_YEARS = 3
+
 		// Device-ship year of the flagship generation that first ships with each Media Performance Class,
-		// on the SAME convention as the scored path's KNOWN_CORE_GENERATION_YEARS (MPC 33 / Android 13 ->
+		// on the SAME convention as the scored path's KNOWN_CORE_DESIGNS years (MPC 33 / Android 13 ->
 		// Galaxy S23 gen, 2023) - not the Android release year, which runs a year ahead. Covers only the
 		// certified path (MIDR is never consulted here). Gates at TIRAMISU (see
 		// PerformanceManager.MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS); an unmapped (newer) class stays EXCELLENT.
@@ -233,12 +261,18 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		// tier is age-decayed (see readCachedHardwareTiers).
 		private const val KEY_CACHE_YEAR = "cache_year"
 
-		// Only the two hardware-derived inputs are cached; the premium gate is re-applied per read.
+		// The hardware-derived inputs are cached; the premium gate is re-applied per read.
 		private const val KEY_SCORED_TIER_LEVEL = "scored_tier_level"
 		private const val KEY_HARDWARE_CAP_LEVEL = "hardware_cap_level"
 
+		// The scored flagship generation year (hardware-stable; distinct from KEY_CACHE_YEAR, the
+		// calendar year the cache was written). NO_GENERATION_YEAR (0, never a real year) means an
+		// undatable chip (Oryon/uncatalogued), which the premium gate reads as "age via certification".
+		private const val KEY_SCORED_GENERATION_YEAR = "scored_generation_year"
+		private const val NO_GENERATION_YEAR = 0
+
 		// Bump when the scoring algorithm, core-weight table, tier thresholds, age-decay logic or
 		// hardware cap change, so tiers cached by older logic are recomputed.
-		private const val CACHE_SCHEMA_VERSION = 2
+		private const val CACHE_SCHEMA_VERSION = 3
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
@@ -20,9 +20,10 @@ import java.util.Calendar
  * The tier comes from a microarchitecture score ([CpuArchitectureScorer]) with three adjustments: an
  * EXCELLENT tier is capped to HIGH once its flagship silicon generation is a few years old
  * ([capOldFlagship]), so "EXCELLENT can handle every feature" keeps describing current flagships and
- * not once-flagship hardware; a Media-Performance-Class certification overrides the score and is aged
- * the same way ([premiumCertifiedTier]); and platform low-end signals ([measureHardwareCap]) cap the
- * result so a fast SoC paired with starved memory never reports a rich-experience tier.
+ * not once-flagship hardware; a Media-Performance-Class certification short-circuits the score while it
+ * is current and defers back to it once aged out ([premiumCertifiedTier]); and platform low-end signals
+ * ([measureHardwareCap]) cap the result so a fast SoC paired with starved memory never reports a
+ * rich-experience tier.
  *
  * The hardware inputs are fixed, so they are measured once, persisted and served from cache on later
  * launches. Because the score now ages with the calendar, the cache is keyed by both
@@ -52,10 +53,11 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	private fun computeDeviceTier(): PerformanceLevel {
 		val hardwareCap = measureHardwareCap()
 
-		// No MIDR info: the hardware cap is the whole answer either way, and the procfs read may
-		// succeed on a later launch, so nothing is cached.
-		val scoredTier = measureMicroarchitectureTier()
-			?: return hardwareCap.also { logInfo("NO MICROARCHITECTURE INFO, DEVICE TIER (NOT CACHED): $it") }
+		// No MIDR info (x86 emulator, restricted procfs): no score to defer to, so the premium gate
+		// still applies directly; the procfs read may succeed on a later launch, so nothing is cached.
+		val scoredTier = measureMicroarchitectureTier() ?: return (
+			if (isPremiumCertified()) minLevel(hardwareCap, premiumCertifiedTier()) else hardwareCap
+			).also { logInfo("NO MICROARCHITECTURE INFO, DEVICE TIER (NOT CACHED): $it") }
 
 		writeCachedHardwareTiers(scoredTier, hardwareCap)
 		return applyPremiumGate(scoredTier, hardwareCap).also { logInfo("DEVICE TIER: $it") }
@@ -64,30 +66,33 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	/**
 	 * Applied per read, never persisted: Play Services resolves the Media Performance Class
 	 * asynchronously, so a first-ever launch can read the framework default and miss a real
-	 * certification - caching that would make the miss permanent. A certified device is limited by
-	 * its hardware cap and by the age of the certification ([premiumCertifiedTier]): certification
-	 * vouches for the SoC, not for the memory it is paired with, and an old certification no longer
-	 * implies a device that can handle every feature.
+	 * certification - caching that would make the miss permanent. A current certification short-circuits
+	 * the score to the hardware cap (it vouches for the SoC, not the memory). Once aged out
+	 * ([premiumCertifiedTier]) it no longer implies a current flagship, but a class is an OEM-declared
+	 * floor a current flagship can under-declare, so the tier defers to the score rather than hard-capping.
 	 */
 	private fun applyPremiumGate(scoredTier: PerformanceLevel, hardwareCap: PerformanceLevel): PerformanceLevel =
-		if (isPremiumCertified()) minLevel(hardwareCap, premiumCertifiedTier())
+		if (isPremiumCertified() && premiumCertifiedTier() == PerformanceLevel.EXCELLENT) hardwareCap
 		else minLevel(scoredTier, hardwareCap)
 
 	/**
-	 * Ages the certified path the same way the scored path is aged. A Media Performance Class is a
-	 * certification against a given Android release, so once that release is
-	 * [OLD_FLAGSHIP_MIN_AGE_YEARS]+ years old the device is no longer a current flagship and drops
-	 * from EXCELLENT to HIGH. An unrecognised (newer-than-table) class yields no year and stays
-	 * EXCELLENT - a just-released device must not be aged.
+	 * Whether the certification is still current or has aged out. Keyed by the device-ship year the
+	 * Media Performance Class maps to ([FLAGSHIP_SHIP_YEAR_BY_SDK_INT]) on the same convention as the
+	 * scored path, so both paths age alike. An unrecognised (newer-than-table) class yields no year and
+	 * stays EXCELLENT - a just-released device must not be aged. This only decides whether to keep the
+	 * certification short-circuit; an aged-out class defers to the score (see [applyPremiumGate]).
 	 */
 	private fun premiumCertifiedTier(): PerformanceLevel {
 		val mediaPerformanceClass = DevicePerformanceProvider.get(applicationContext).mediaPerformanceClass
-		val releaseYear = ANDROID_RELEASE_YEAR_BY_SDK_INT[mediaPerformanceClass] ?: return PerformanceLevel.EXCELLENT
-		return if (currentYear() - releaseYear >= OLD_FLAGSHIP_MIN_AGE_YEARS) PerformanceLevel.HIGH
-		else PerformanceLevel.EXCELLENT
+		val shipYear = FLAGSHIP_SHIP_YEAR_BY_SDK_INT[mediaPerformanceClass] ?: return PerformanceLevel.EXCELLENT
+		return if (isOldFlagship(shipYear)) PerformanceLevel.HIGH else PerformanceLevel.EXCELLENT
 	}
 
 	private fun currentYear(): Int = Calendar.getInstance().get(Calendar.YEAR)
+
+	/** A silicon generation or certification is "old flagship" once it is [OLD_FLAGSHIP_MIN_AGE_YEARS]+ years old. */
+	private fun isOldFlagship(generationYear: Int): Boolean =
+		currentYear() - generationYear >= OLD_FLAGSHIP_MIN_AGE_YEARS
 
 	private fun measureMicroarchitectureTier(): PerformanceLevel? {
 		val (score, flagshipGenerationYear) = architectureScorer.computeScore(cpuInfoManager.coreMaxFreqsInKHz)
@@ -111,8 +116,8 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	 * touched; a null year (uncatalogued or unreadable top core) is treated as current and left as-is.
 	 */
 	private fun capOldFlagship(tier: PerformanceLevel, flagshipGenerationYear: Int?): PerformanceLevel =
-		if (tier == PerformanceLevel.EXCELLENT && flagshipGenerationYear != null &&
-			currentYear() - flagshipGenerationYear >= OLD_FLAGSHIP_MIN_AGE_YEARS) PerformanceLevel.HIGH
+		if (tier == PerformanceLevel.EXCELLENT && flagshipGenerationYear != null && isOldFlagship(flagshipGenerationYear))
+			PerformanceLevel.HIGH
 		else tier
 
 	/** Platform low-end signals cap the tier. Memory-class ranges start at 1 because 0 means "unknown". */
@@ -197,16 +202,16 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		// silicon generation (scored path) or certification (MPC path) is this many years old.
 		private const val OLD_FLAGSHIP_MIN_AGE_YEARS = 3
 
-		// Android release year per Media Performance Class (the API level it certifies against), used
-		// to age the MPC short-circuit. The scored path derives its generation year from core MIDR ids
-		// instead; this map covers only the certified path, where MIDR is never consulted. Certification
-		// gates at TIRAMISU (see PerformanceManager.MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS), so entries
-		// start there; an unmapped (newer) class is treated as current and stays EXCELLENT.
-		private val ANDROID_RELEASE_YEAR_BY_SDK_INT: Map<Int, Int> = mapOf(
-			Build.VERSION_CODES.TIRAMISU to 2022,          // Android 13
-			Build.VERSION_CODES.UPSIDE_DOWN_CAKE to 2023,  // Android 14
-			Build.VERSION_CODES.VANILLA_ICE_CREAM to 2024, // Android 15
-			Build.VERSION_CODES.BAKLAVA to 2025,           // Android 16
+		// Device-ship year of the flagship generation that first ships with each Media Performance Class,
+		// on the SAME convention as the scored path's KNOWN_CORE_GENERATION_YEARS (MPC 33 / Android 13 ->
+		// Galaxy S23 gen, 2023) - not the Android release year, which runs a year ahead. Covers only the
+		// certified path (MIDR is never consulted here). Gates at TIRAMISU (see
+		// PerformanceManager.MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS); an unmapped (newer) class stays EXCELLENT.
+		private val FLAGSHIP_SHIP_YEAR_BY_SDK_INT: Map<Int, Int> = mapOf(
+			Build.VERSION_CODES.TIRAMISU to 2023,          // Android 13 -> Galaxy S23 generation
+			Build.VERSION_CODES.UPSIDE_DOWN_CAKE to 2024,  // Android 14 -> Galaxy S24 generation
+			Build.VERSION_CODES.VANILLA_ICE_CREAM to 2025, // Android 15 -> 2025 flagships
+			Build.VERSION_CODES.BAKLAVA to 2026,           // Android 16 -> 2026 flagships
 		)
 
 		private const val LOW_TIER_MAX_CORE_COUNT = 2
@@ -234,6 +239,6 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 
 		// Bump when the scoring algorithm, core-weight table, tier thresholds, age-decay logic or
 		// hardware cap change, so tiers cached by older logic are recomputed.
-		private const val CACHE_SCHEMA_VERSION = 1
+		private const val CACHE_SCHEMA_VERSION = 2
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/CpuPerformanceManager.kt
@@ -8,22 +8,27 @@ import com.blinkit.droiddex.cpu.utils.CpuArchitectureScorer
 import com.blinkit.droiddex.cpu.utils.CpuInfoManager
 import com.blinkit.droiddex.factory.base.PerformanceManager
 import com.blinkit.droiddex.factory.providers.PerformanceManagerProvider
+import com.blinkit.droiddex.utils.DevicePerformanceProvider
 import com.blinkit.droiddex.utils.getMemoryClassInMB
 import com.blinkit.droiddex.utils.getTotalRamInGB
 import com.blinkit.droiddex.utils.isLowRamDevice
+import java.util.Calendar
 
 /**
- * Classifies the device's CPU into a fixed hardware tier.
+ * Classifies the device's CPU into a hardware tier.
  *
- * The tier comes from a microarchitecture score ([CpuArchitectureScorer]) with two adjustments: a
- * Media-Performance-Class certification overrides the score, and platform low-end signals
- * ([measureHardwareCap]) cap the result so a fast SoC paired with starved memory never reports a
- * rich-experience tier.
+ * The tier comes from a microarchitecture score ([CpuArchitectureScorer]) with three adjustments: an
+ * EXCELLENT tier is capped to HIGH once its flagship silicon generation is a few years old
+ * ([capOldFlagship]), so "EXCELLENT can handle every feature" keeps describing current flagships and
+ * not once-flagship hardware; a Media-Performance-Class certification overrides the score and is aged
+ * the same way ([premiumCertifiedTier]); and platform low-end signals ([measureHardwareCap]) cap the
+ * result so a fast SoC paired with starved memory never reports a rich-experience tier.
  *
- * Both hardware inputs are fixed, so they are measured once, persisted and served from cache on
- * later launches; the cache invalidates only on a deliberate [CACHE_SCHEMA_VERSION] bump, and the
- * certification gate stays outside it (see [applyPremiumGate]). Devices with no readable MIDR info
- * (x86 emulators, restricted procfs) fall back to the hardware cap alone and are not cached.
+ * The hardware inputs are fixed, so they are measured once, persisted and served from cache on later
+ * launches. Because the score now ages with the calendar, the cache is keyed by both
+ * [CACHE_SCHEMA_VERSION] and the current year, so a persisted tier is re-derived at most once a year;
+ * the certification gate stays outside the cache (see [applyPremiumGate]). Devices with no readable
+ * MIDR info (x86 emulators, restricted procfs) fall back to the hardware cap alone and are not cached.
  */
 internal class CpuPerformanceManager(applicationContext: Context): PerformanceManager(applicationContext) {
 
@@ -60,21 +65,55 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 	 * Applied per read, never persisted: Play Services resolves the Media Performance Class
 	 * asynchronously, so a first-ever launch can read the framework default and miss a real
 	 * certification - caching that would make the miss permanent. A certified device is limited by
-	 * its hardware cap alone, since certification vouches for the SoC and not for the memory it is
-	 * paired with.
+	 * its hardware cap and by the age of the certification ([premiumCertifiedTier]): certification
+	 * vouches for the SoC, not for the memory it is paired with, and an old certification no longer
+	 * implies a device that can handle every feature.
 	 */
 	private fun applyPremiumGate(scoredTier: PerformanceLevel, hardwareCap: PerformanceLevel): PerformanceLevel =
-		if (isPremiumCertified()) hardwareCap else minLevel(scoredTier, hardwareCap)
+		if (isPremiumCertified()) minLevel(hardwareCap, premiumCertifiedTier())
+		else minLevel(scoredTier, hardwareCap)
+
+	/**
+	 * Ages the certified path the same way the scored path is aged. A Media Performance Class is a
+	 * certification against a given Android release, so once that release is
+	 * [OLD_FLAGSHIP_MIN_AGE_YEARS]+ years old the device is no longer a current flagship and drops
+	 * from EXCELLENT to HIGH. An unrecognised (newer-than-table) class yields no year and stays
+	 * EXCELLENT - a just-released device must not be aged.
+	 */
+	private fun premiumCertifiedTier(): PerformanceLevel {
+		val mediaPerformanceClass = DevicePerformanceProvider.get(applicationContext).mediaPerformanceClass
+		val releaseYear = ANDROID_RELEASE_YEAR_BY_SDK_INT[mediaPerformanceClass] ?: return PerformanceLevel.EXCELLENT
+		return if (currentYear() - releaseYear >= OLD_FLAGSHIP_MIN_AGE_YEARS) PerformanceLevel.HIGH
+		else PerformanceLevel.EXCELLENT
+	}
+
+	private fun currentYear(): Int = Calendar.getInstance().get(Calendar.YEAR)
 
 	private fun measureMicroarchitectureTier(): PerformanceLevel? {
-		val score = architectureScorer.computeScore(cpuInfoManager.coreMaxFreqsInKHz) ?: return null
-		return when {
+		val (score, flagshipGenerationYear) = architectureScorer.computeScore(cpuInfoManager.coreMaxFreqsInKHz)
+			?: return null
+		val scoredTier = when {
 			score < LOW_TIER_MAX_SCORE -> PerformanceLevel.LOW
 			score < AVERAGE_TIER_MAX_SCORE -> PerformanceLevel.AVERAGE
 			score < HIGH_TIER_MAX_SCORE -> PerformanceLevel.HIGH
 			else -> PerformanceLevel.EXCELLENT
-		}.also { logInfo("MICROARCHITECTURE SCORE: $score -> $it") }
+		}
+		return capOldFlagship(scoredTier, flagshipGenerationYear).also {
+			logInfo("MICROARCHITECTURE SCORE: $score (flagship generation $flagshipGenerationYear) -> $it")
+		}
 	}
+
+	/**
+	 * Ages the scored path the same way the certified path is aged ([premiumCertifiedTier]): an
+	 * EXCELLENT chip whose flagship silicon generation is [OLD_FLAGSHIP_MIN_AGE_YEARS]+ years old is no
+	 * longer a current flagship and drops to HIGH. Only EXCELLENT is capped, so a mid-tier chip that
+	 * merely shares a core design with an old flagship (e.g. Snapdragon 7 Gen 3's A715) is never
+	 * touched; a null year (uncatalogued or unreadable top core) is treated as current and left as-is.
+	 */
+	private fun capOldFlagship(tier: PerformanceLevel, flagshipGenerationYear: Int?): PerformanceLevel =
+		if (tier == PerformanceLevel.EXCELLENT && flagshipGenerationYear != null &&
+			currentYear() - flagshipGenerationYear >= OLD_FLAGSHIP_MIN_AGE_YEARS) PerformanceLevel.HIGH
+		else tier
 
 	/** Platform low-end signals cap the tier. Memory-class ranges start at 1 because 0 means "unknown". */
 	private fun measureHardwareCap(): PerformanceLevel {
@@ -96,9 +135,14 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		}
 	}
 
-	/** Both halves must be present to be usable, so a partial write is treated as no cache at all. */
+	/**
+	 * Both halves must be present to be usable, so a partial write is treated as no cache at all. The
+	 * year is part of the validity check because the scored tier is age-decayed: a tier cached last
+	 * year may need to drop this year, so a stale-year cache is ignored and recomputed.
+	 */
 	private fun readCachedHardwareTiers(): Pair<PerformanceLevel, PerformanceLevel>? = try {
-		if (cachePrefs.getInt(KEY_CACHE_SCHEMA_VERSION, 0) == CACHE_SCHEMA_VERSION) {
+		if (cachePrefs.getInt(KEY_CACHE_SCHEMA_VERSION, 0) == CACHE_SCHEMA_VERSION &&
+			cachePrefs.getInt(KEY_CACHE_YEAR, 0) == currentYear()) {
 			val scoredTier = readCachedLevel(KEY_SCORED_TIER_LEVEL)
 			val hardwareCap = readCachedLevel(KEY_HARDWARE_CAP_LEVEL)
 			if (scoredTier != null && hardwareCap != null) scoredTier to hardwareCap else null
@@ -116,6 +160,7 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		try {
 			cachePrefs.edit()
 				.putInt(KEY_CACHE_SCHEMA_VERSION, CACHE_SCHEMA_VERSION)
+				.putInt(KEY_CACHE_YEAR, currentYear())
 				.putInt(KEY_SCORED_TIER_LEVEL, scoredTier.level)
 				.putInt(KEY_HARDWARE_CAP_LEVEL, hardwareCap.level)
 				.apply()
@@ -139,10 +184,30 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		// LOW < 20:        8xA53/A55 designs (Exynos 850 ~19, Unisoc T606 ~18.5)
 		// AVERAGE 20-34:   Helio G85 ~22, SD 680 ~27, Helio G99 ~27, SD 695 ~28, Exynos 1280 ~31
 		// HIGH 34-56:      SD 778G ~40, SD 888 ~44, Exynos 1480 ~47, 8 Gen 1 ~50, D9200 ~55
-		// EXCELLENT >= 56: 2022+ flagship silicon (Tensor G3 ~57, 8 Gen 2 ~63, 8 Elite ~130)
+		// EXCELLENT >= 56: current flagship silicon (8 Gen 3 ~82, D9400 ~103, 8 Elite ~130). An
+		//                  EXCELLENT tier is then age-capped to HIGH by capOldFlagship once the device's
+		//                  flagship silicon generation is OLD_FLAGSHIP_MIN_AGE_YEARS+ years old, so
+		//                  once-flagship chips (Tensor G3 ~57, 8 Gen 2 ~63) fall to HIGH while current
+		//                  flagships stay EXCELLENT. The raw score is never modified - only the tier.
 		private const val LOW_TIER_MAX_SCORE = 20F
 		private const val AVERAGE_TIER_MAX_SCORE = 34F
 		private const val HIGH_TIER_MAX_SCORE = 56F
+
+		// A device is "old flagship" - no longer assumed able to handle every feature - once its
+		// silicon generation (scored path) or certification (MPC path) is this many years old.
+		private const val OLD_FLAGSHIP_MIN_AGE_YEARS = 3
+
+		// Android release year per Media Performance Class (the API level it certifies against), used
+		// to age the MPC short-circuit. The scored path derives its generation year from core MIDR ids
+		// instead; this map covers only the certified path, where MIDR is never consulted. Certification
+		// gates at TIRAMISU (see PerformanceManager.MIN_PREMIUM_MEDIA_PERFORMANCE_CLASS), so entries
+		// start there; an unmapped (newer) class is treated as current and stays EXCELLENT.
+		private val ANDROID_RELEASE_YEAR_BY_SDK_INT: Map<Int, Int> = mapOf(
+			Build.VERSION_CODES.TIRAMISU to 2022,          // Android 13
+			Build.VERSION_CODES.UPSIDE_DOWN_CAKE to 2023,  // Android 14
+			Build.VERSION_CODES.VANILLA_ICE_CREAM to 2024, // Android 15
+			Build.VERSION_CODES.BAKLAVA to 2025,           // Android 16
+		)
 
 		private const val LOW_TIER_MAX_CORE_COUNT = 2
 
@@ -159,12 +224,16 @@ internal class CpuPerformanceManager(applicationContext: Context): PerformanceMa
 		private const val CACHE_PREFS_NAME = "com.blinkit.droiddex.cpu_tier_cache"
 		private const val KEY_CACHE_SCHEMA_VERSION = "cache_schema_version"
 
+		// The calendar year the cache was written in; a stale year invalidates it because the scored
+		// tier is age-decayed (see readCachedHardwareTiers).
+		private const val KEY_CACHE_YEAR = "cache_year"
+
 		// Only the two hardware-derived inputs are cached; the premium gate is re-applied per read.
 		private const val KEY_SCORED_TIER_LEVEL = "scored_tier_level"
 		private const val KEY_HARDWARE_CAP_LEVEL = "hardware_cap_level"
 
-		// Bump when the scoring algorithm, core-weight table, tier thresholds or hardware cap
-		// change, so tiers cached by older logic are recomputed.
+		// Bump when the scoring algorithm, core-weight table, tier thresholds, age-decay logic or
+		// hardware cap change, so tiers cached by older logic are recomputed.
 		private const val CACHE_SCHEMA_VERSION = 1
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
@@ -9,7 +9,7 @@ import java.io.File
  * speed, the core design cannot be faked by OEMs.
  *
  * The score is a synthetic throughput estimate: sum over all cores of (relative single-thread
- * weight of the core design) x (max frequency in GHz). A design absent from [KNOWN_CORE_WEIGHTS] is
+ * weight of the core design) x (max frequency in GHz). A design absent from [KNOWN_CORE_DESIGNS] is
  * newer than the table, so it scores as the newest known core of its cluster role - future SoCs
  * tier correctly without a library update.
  *
@@ -48,7 +48,7 @@ internal class CpuArchitectureScorer(
 		var score = 0F
 		for (core in 0 until coreCount) {
 			val midrId = midrIdsByCore[core] ?: findClusterMateMidrId(core, freqsInKHz, midrIdsByCore)
-			val weight = midrId?.let { KNOWN_CORE_WEIGHTS[it] } ?: run {
+			val weight = midrId?.let { KNOWN_CORE_DESIGNS[it]?.weight } ?: run {
 				val roleWeight = roleBasedWeight(freqsInKHz[core], deviceMaxFreqInKHz, topFreqCoreCount)
 				val coreDesign = midrId?.let { "UNKNOWN CORE DESIGN $it" } ?: "NO CORE DESIGN"
 				logger.logDebug("$coreDesign ON CPU$core, ROLE-BASED WEIGHT: $roleWeight")
@@ -81,7 +81,7 @@ internal class CpuArchitectureScorer(
 		var newestYear: Int? = null
 		for (core in topCores) {
 			val midrId = midrIdsByCore[core] ?: findClusterMateMidrId(core, freqsInKHz, midrIdsByCore)
-			val year = midrId?.let { KNOWN_CORE_GENERATION_YEARS[it] } ?: return null
+			val year = midrId?.let { KNOWN_CORE_DESIGNS[it]?.generationYear } ?: return null
 			newestYear = maxOf(newestYear ?: year, year)
 		}
 		return newestYear
@@ -166,6 +166,13 @@ internal class CpuArchitectureScorer(
 	 */
 	internal data class CpuScore(val score: Float, val flagshipGenerationYear: Int?)
 
+	/**
+	 * @param weight scoring weight (relative single-thread capability per GHz)
+	 * @param generationYear device-ship year of the newest flagship generation using this design as a
+	 * prime, or null when the design never dates a device (efficiency/mid role, or Oryon)
+	 */
+	internal data class CoreDesign(val weight: Float, val generationYear: Int?)
+
 	companion object {
 
 		private const val CPU_INFO_PATH = "/proc/cpuinfo"
@@ -197,98 +204,86 @@ internal class CpuArchitectureScorer(
 		private fun samsung(part: Int) = MidrId(SAMSUNG, part)
 
 		/**
-		 * Relative single-thread capability per GHz, coarsely anchored to public Geekbench 6
-		 * single-core results (unitless - only ratios and the tier thresholds matter). Keyed by core
-		 * design, not SoC: ARM ships ~3 mobile ids per year.
-		 */
-		private val KNOWN_CORE_WEIGHTS: Map<MidrId, Float> = mapOf(
-			// ARM efficiency cores
-			arm(0xd03) to 1.0F, // Cortex-A53
-			arm(0xd04) to 1.0F, // Cortex-A35
-			arm(0xd05) to 1.2F, // Cortex-A55
-			arm(0xd46) to 1.4F, // Cortex-A510
-			arm(0xd80) to 1.5F, // Cortex-A520
-			arm(0xd8f) to 1.5F, // Cortex-A320
-			arm(0xd8a) to 1.6F, // C1-Nano
-			// ARM big cores, ARMv8 2016-18
-			arm(0xd07) to 1.6F, // Cortex-A57
-			arm(0xd08) to 1.9F, // Cortex-A72
-			arm(0xd09) to 2.0F, // Cortex-A73
-			arm(0xd0a) to 2.2F, // Cortex-A75
-			// ARM big cores, ARMv8 2019-21
-			arm(0xd0b) to 2.8F, // Cortex-A76
-			arm(0xd0d) to 3.1F, // Cortex-A77
-			arm(0xd41) to 3.4F, // Cortex-A78
-			arm(0xd4b) to 3.4F, // Cortex-A78C
-			arm(0xd44) to 3.9F, // Cortex-X1
-			arm(0xd4c) to 3.9F, // Cortex-X1C
-			// ARM big cores, ARMv9 gen 1-2
-			arm(0xd47) to 3.6F, // Cortex-A710
-			arm(0xd4d) to 3.7F, // Cortex-A715
-			arm(0xd48) to 4.1F, // Cortex-X2
-			arm(0xd4e) to 4.4F, // Cortex-X3
-			// ARM big cores, ARMv9 gen 3+
-			arm(0xd81) to 3.9F, // Cortex-A720
-			arm(0xd87) to 4.1F, // Cortex-A725
-			arm(0xd82) to 4.7F, // Cortex-X4
-			arm(0xd85) to 5.2F, // Cortex-X925
-			arm(0xd8b) to 4.3F, // C1-Pro
-			arm(0xd90) to 5.0F, // C1-Premium
-			arm(0xd8c) to 5.6F, // C1-Ultra
-			// HiSilicon (Kirin) relabels licensed ARM designs under its own implementer id, so the
-			// same part number means a different core than under ARM: 0xd41 is A77 here, A78 there.
-			hisilicon(0xd40) to 2.8F, // Cortex-A76 (Kirin 980/990)
-			hisilicon(0xd41) to 3.1F, // Cortex-A77 (Kirin 9000)
-			hisilicon(0xd01) to 2.2F, // TaiShan v110 (Kunpeng, server)
-			hisilicon(0xd02) to 2.8F, // TaiShan v120 (Kunpeng, server)
-			// Qualcomm custom + semi-custom (rebranded ARM) designs
-			qualcomm(0x001) to 5.0F, // Oryon
-			qualcomm(0x205) to 1.8F, // Kryo 1xx Gold (SD 820/821)
-			qualcomm(0x211) to 1.6F, // Kryo 1xx Silver
-			qualcomm(0x800) to 2.0F, // Kryo 2xx Gold (A73-class)
-			qualcomm(0x801) to 1.0F, // Kryo 2xx Silver (A53-class)
-			qualcomm(0x802) to 2.2F, // Kryo 3xx Gold (A75-class)
-			qualcomm(0x803) to 1.2F, // Kryo 3xx Silver (A55-class)
-			qualcomm(0x804) to 2.8F, // Kryo 4xx Gold (A76-class)
-			qualcomm(0x805) to 1.2F, // Kryo 4xx Silver (A55-class)
-			// Samsung custom big cores (Exynos M-series, discontinued 2020)
-			samsung(0x001) to 1.7F, // Mongoose M1/M2
-			samsung(0x002) to 2.2F, // Mongoose M3
-			samsung(0x003) to 2.6F, // Mongoose M4
-			samsung(0x004) to 2.7F, // Mongoose M5
-		)
-
-		/**
-		 * Ship year of the NEWEST flagship device generation to use this core design as a prime - not the
-		 * design's debut year. A prime is often reused a generation later (Cortex-X4: 8 Gen 3 2024, then
-		 * Tensor G5 / Pixel 10 2025) and MIDR alone cannot tell the devices apart, so the entry takes the
-		 * latest reuse - keeping a reusing flagship EXCELLENT a year longer rather than demoting it early.
-		 * Deliberately sparse: only cores that can carry a device to EXCELLENT need a year.
-		 * A new prime design added to [KNOWN_CORE_WEIGHTS] should get an entry here too; until it does,
-		 * an uncatalogued prime yields no year and is treated as current - so a just-launched flagship
-		 * is never aged. That fail-safe direction is the invariant: a MIDR (implementer, part) may be
-		 * listed only if it uniquely identifies one generation.
+		 * Per core design (keyed by MIDR, not SoC - ARM ships ~3 mobile ids/year): its scoring
+		 * [CoreDesign.weight] and, for prime cores, the [CoreDesign.generationYear] used to age EXCELLENT.
+		 *
+		 * weight = relative single-thread capability per GHz, coarsely anchored to public Geekbench 6
+		 * single-core results (unitless - only ratios and the tier thresholds matter). A design absent
+		 * here is newer than the table and scores as the newest known core of its cluster role (see
+		 * [roleBasedWeight]).
+		 *
+		 * generationYear = ship year of the NEWEST flagship generation to use this design as a prime, or
+		 * null for a design that never dates a device (efficiency/mid roles, and Qualcomm's Oryon - see
+		 * below). NOT the design's debut year: a prime is often reused a generation later (Cortex-X4:
+		 * 8 Gen 3 2024, then Tensor G5 / Pixel 10 2025) and MIDR cannot tell the devices apart, so the
+		 * entry takes the latest reuse - keeping a reusing flagship EXCELLENT a year longer rather than
+		 * demoting it early. The year has no default, so adding a design forces an explicit year-or-null
+		 * choice at the line rather than a silently forgotten one.
 		 *
 		 * ARM assigns a fresh part per core design (X2 0xd48 -> X3 0xd4e -> X4 0xd82), as does Qualcomm
-		 * for its Kryo parts, so each maps to exactly one generation. Qualcomm's Oryon is deliberately
-		 * NOT listed: every Oryon generation (Snapdragon X Elite, 8 Elite and successors) reports the
-		 * same part 0x001, told apart only by the MIDR variant field, which [parseMidrIds] does not read.
-		 * Mapping 0x001 to any single year would wrongly demote a future Oryon flagship, so Oryon
-		 * devices fall through to no-year and stay EXCELLENT (aged only via the Media-Performance-Class
-		 * path, when they declare one).
+		 * for its Kryo parts, so each dates one generation. Qualcomm's Oryon is null on purpose: every
+		 * Oryon generation (Snapdragon X Elite, 8 Elite and successors) reports the same part 0x001, told
+		 * apart only by the MIDR variant field which [parseMidrIds] does not read - dating it to any one
+		 * year would wrongly demote a future Oryon flagship, so the scored path leaves it null and its
+		 * aging is left to the certification path (CpuPerformanceManager.applyPremiumGate). The Oryon null
+		 * and the X4-reuse bump are the same limitation: MIDR cannot distinguish generations; the real fix
+		 * is an SoC-identity signal.
 		 */
-		private val KNOWN_CORE_GENERATION_YEARS: Map<MidrId, Int> = mapOf(
-			arm(0xd48) to 2022, // Cortex-X2   (Snapdragon 8 Gen 1 / Tensor G2)
-			arm(0xd47) to 2022, // Cortex-A710 (same generation)
-			arm(0xd4e) to 2023, // Cortex-X3   (Snapdragon 8 Gen 2 / Tensor G3 - Galaxy S23)
-			arm(0xd4d) to 2023, // Cortex-A715 (same generation)
-			arm(0xd82) to 2025, // Cortex-X4   (8 Gen 3 2024, reused in Tensor G5 / Pixel 10 2025)
-			arm(0xd81) to 2024, // Cortex-A720 (Snapdragon 8 Gen 3 / Tensor G4)
-			arm(0xd85) to 2025, // Cortex-X925 (Dimensity 9400)
-			arm(0xd87) to 2025, // Cortex-A725 (same generation)
-			arm(0xd8b) to 2026, // C1-Pro
-			arm(0xd90) to 2026, // C1-Premium
-			arm(0xd8c) to 2026, // C1-Ultra
+		private val KNOWN_CORE_DESIGNS: Map<MidrId, CoreDesign> = mapOf(
+			// ARM efficiency cores
+			arm(0xd03) to CoreDesign(1.0F, null), // Cortex-A53
+			arm(0xd04) to CoreDesign(1.0F, null), // Cortex-A35
+			arm(0xd05) to CoreDesign(1.2F, null), // Cortex-A55
+			arm(0xd46) to CoreDesign(1.4F, null), // Cortex-A510
+			arm(0xd80) to CoreDesign(1.5F, null), // Cortex-A520
+			arm(0xd8f) to CoreDesign(1.5F, null), // Cortex-A320
+			arm(0xd8a) to CoreDesign(1.6F, null), // C1-Nano
+			// ARM big cores, ARMv8 2016-18
+			arm(0xd07) to CoreDesign(1.6F, null), // Cortex-A57
+			arm(0xd08) to CoreDesign(1.9F, null), // Cortex-A72
+			arm(0xd09) to CoreDesign(2.0F, null), // Cortex-A73
+			arm(0xd0a) to CoreDesign(2.2F, null), // Cortex-A75
+			// ARM big cores, ARMv8 2019-21
+			arm(0xd0b) to CoreDesign(2.8F, null), // Cortex-A76
+			arm(0xd0d) to CoreDesign(3.1F, null), // Cortex-A77
+			arm(0xd41) to CoreDesign(3.4F, null), // Cortex-A78
+			arm(0xd4b) to CoreDesign(3.4F, null), // Cortex-A78C
+			arm(0xd44) to CoreDesign(3.9F, null), // Cortex-X1
+			arm(0xd4c) to CoreDesign(3.9F, null), // Cortex-X1C
+			// ARM big cores, ARMv9 gen 1-2
+			arm(0xd47) to CoreDesign(3.6F, 2022), // Cortex-A710 (8 Gen 1 / Tensor G2 gen)
+			arm(0xd4d) to CoreDesign(3.7F, 2023), // Cortex-A715 (8 Gen 2 / Tensor G3 gen)
+			arm(0xd48) to CoreDesign(4.1F, 2022), // Cortex-X2   (Snapdragon 8 Gen 1 / Tensor G2)
+			arm(0xd4e) to CoreDesign(4.4F, 2023), // Cortex-X3   (Snapdragon 8 Gen 2 / Tensor G3 - Galaxy S23)
+			// ARM big cores, ARMv9 gen 3+
+			arm(0xd81) to CoreDesign(3.9F, 2024), // Cortex-A720 (Snapdragon 8 Gen 3 / Tensor G4)
+			arm(0xd87) to CoreDesign(4.1F, 2025), // Cortex-A725 (Dimensity 9400 gen)
+			arm(0xd82) to CoreDesign(4.7F, 2025), // Cortex-X4   (8 Gen 3 2024, reused in Tensor G5 / Pixel 10 2025)
+			arm(0xd85) to CoreDesign(5.2F, 2025), // Cortex-X925 (Dimensity 9400)
+			arm(0xd8b) to CoreDesign(4.3F, 2026), // C1-Pro
+			arm(0xd90) to CoreDesign(5.0F, 2026), // C1-Premium
+			arm(0xd8c) to CoreDesign(5.6F, 2026), // C1-Ultra
+			// HiSilicon (Kirin) relabels licensed ARM designs under its own implementer id, so the
+			// same part number means a different core than under ARM: 0xd41 is A77 here, A78 there.
+			hisilicon(0xd40) to CoreDesign(2.8F, null), // Cortex-A76 (Kirin 980/990)
+			hisilicon(0xd41) to CoreDesign(3.1F, null), // Cortex-A77 (Kirin 9000)
+			hisilicon(0xd01) to CoreDesign(2.2F, null), // TaiShan v110 (Kunpeng, server)
+			hisilicon(0xd02) to CoreDesign(2.8F, null), // TaiShan v120 (Kunpeng, server)
+			// Qualcomm custom + semi-custom (rebranded ARM) designs
+			qualcomm(0x001) to CoreDesign(5.0F, null), // Oryon (null year: part 0x001 shared by all Oryon gens - see above)
+			qualcomm(0x205) to CoreDesign(1.8F, null), // Kryo 1xx Gold (SD 820/821)
+			qualcomm(0x211) to CoreDesign(1.6F, null), // Kryo 1xx Silver
+			qualcomm(0x800) to CoreDesign(2.0F, null), // Kryo 2xx Gold (A73-class)
+			qualcomm(0x801) to CoreDesign(1.0F, null), // Kryo 2xx Silver (A53-class)
+			qualcomm(0x802) to CoreDesign(2.2F, null), // Kryo 3xx Gold (A75-class)
+			qualcomm(0x803) to CoreDesign(1.2F, null), // Kryo 3xx Silver (A55-class)
+			qualcomm(0x804) to CoreDesign(2.8F, null), // Kryo 4xx Gold (A76-class)
+			qualcomm(0x805) to CoreDesign(1.2F, null), // Kryo 4xx Silver (A55-class)
+			// Samsung custom big cores (Exynos M-series, discontinued 2020)
+			samsung(0x001) to CoreDesign(1.7F, null), // Mongoose M1/M2
+			samsung(0x002) to CoreDesign(2.2F, null), // Mongoose M3
+			samsung(0x003) to CoreDesign(2.6F, null), // Mongoose M4
+			samsung(0x004) to CoreDesign(2.7F, null), // Mongoose M5
 		)
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
@@ -213,8 +213,8 @@ internal class CpuArchitectureScorer(
 		 * [roleBasedWeight]).
 		 *
 		 * generationYear = ship year of the NEWEST flagship generation to use this design as a prime, or
-		 * null for a design that never dates a device (efficiency/mid roles, and Qualcomm's Oryon - see
-		 * below). NOT the design's debut year: a prime is often reused a generation later (Cortex-X4:
+		 * null for a design that never serves as a device's top-frequency core, and for Qualcomm's Oryon
+		 * (see below). NOT the design's debut year: a prime is often reused a generation later (Cortex-X4:
 		 * 8 Gen 3 2024, then Tensor G5 / Pixel 10 2025) and MIDR cannot tell the devices apart, so the
 		 * entry takes the latest reuse - keeping a reusing flagship EXCELLENT a year longer rather than
 		 * demoting it early. The year has no default, so adding a design forces an explicit year-or-null

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
@@ -12,6 +12,11 @@ import java.io.File
  * weight of the core design) x (max frequency in GHz). A design absent from [KNOWN_CORE_WEIGHTS] is
  * newer than the table, so it scores as the newest known core of its cluster role - future SoCs
  * tier correctly without a library update.
+ *
+ * Alongside the score, [computeScore] reports the device's flagship generation year (from its
+ * top-frequency core designs, see [flagshipGenerationYear]). The caller uses it to age an EXCELLENT
+ * chip down to HIGH once its generation is old - the score itself is never modified here, so it
+ * stays a pure hardware capability estimate.
  */
 internal class CpuArchitectureScorer(
 	private val logger: Logger, private val cpuInfoPath: String = CPU_INFO_PATH
@@ -19,10 +24,11 @@ internal class CpuArchitectureScorer(
 
 	/**
 	 * @param coreMaxFreqsInKHz per-core cpuinfo_max_freq, index-aligned with cpu0..cpuN; <= 0 means unknown
-	 * @return the synthetic throughput score, or null when no MIDR info is readable (x86 emulator,
-	 * hidden procfs) - callers must then fall back to a heuristic that does not need it
+	 * @return the raw throughput [CpuScore.score] plus the device's [CpuScore.flagshipGenerationYear]
+	 * (for age-capping by the caller), or null when no MIDR info is readable (x86 emulator, hidden
+	 * procfs) - callers must then fall back to a heuristic that does not need it
 	 */
-	fun computeScore(coreMaxFreqsInKHz: List<Long>): Float? = try {
+	fun computeScore(coreMaxFreqsInKHz: List<Long>): CpuScore? = try {
 		val midrIdsByCore = readCpuInfoText()?.let(::parseMidrIds).orEmpty()
 		if (midrIdsByCore.isEmpty()) null else computeScore(coreMaxFreqsInKHz, midrIdsByCore)
 	} catch (e: Exception) {
@@ -30,7 +36,7 @@ internal class CpuArchitectureScorer(
 		null
 	}
 
-	private fun computeScore(coreMaxFreqsInKHz: List<Long>, midrIdsByCore: Map<Int, MidrId>): Float? {
+	private fun computeScore(coreMaxFreqsInKHz: List<Long>, midrIdsByCore: Map<Int, MidrId>): CpuScore? {
 		val coreCount = maxOf(coreMaxFreqsInKHz.size, midrIdsByCore.keys.max() + 1)
 
 		val freqsInKHz = LongArray(coreCount) { maxOf(coreMaxFreqsInKHz.getOrElse(it) { 0L }, 0L) }
@@ -50,8 +56,34 @@ internal class CpuArchitectureScorer(
 			}
 			score += weight * freqsInKHz[core] / KHZ_PER_GHZ
 		}
-		return score.also { logger.logDebug("MICROARCHITECTURE SCORE: $it") }
+
+		val generationYear = flagshipGenerationYear(freqsInKHz, deviceMaxFreqInKHz, midrIdsByCore)
+		return CpuScore(score, generationYear).also {
+			logger.logDebug("MICROARCHITECTURE SCORE: $score (flagship generation $generationYear)")
+		}
 	}
+
+	/**
+	 * The flagship generation year of the device, read from its top-frequency cores only (>= 95% of
+	 * its own max, [PRIME_ROLE_MIN_RELATIVE_FREQ]) with no count cap - so an all-big design like
+	 * Dimensity 8300 (four A715 cores tied at the top frequency) is covered, while an older efficiency
+	 * core paired with a newer prime (below 95% of it) is ignored. An uncatalogued (newer-than-table)
+	 * top core yields no year, so the caller never ages a just-launched flagship - failing safe toward
+	 * EXCELLENT rather than wrongly demoting new hardware.
+	 *
+	 * A top core missing from /proc/cpuinfo (offline during the read) is resolved from a same-frequency
+	 * cluster mate, matching the scoring loop; only a solo prime that is both offline and mateless
+	 * yields no year - an accepted rare gap, consistent with this file's tolerance for partial cpuinfo.
+	 */
+	private fun flagshipGenerationYear(
+		freqsInKHz: LongArray, deviceMaxFreqInKHz: Long, midrIdsByCore: Map<Int, MidrId>
+	): Int? = freqsInKHz.indices
+		.filter { freqsInKHz[it] >= PRIME_ROLE_MIN_RELATIVE_FREQ * deviceMaxFreqInKHz }
+		.mapNotNull { core ->
+			(midrIdsByCore[core] ?: findClusterMateMidrId(core, freqsInKHz, midrIdsByCore))
+				?.let { KNOWN_CORE_GENERATION_YEARS[it] }
+		}
+		.maxOrNull()
 
 	/**
 	 * Fills frequencies of cores whose cpufreq node was unreadable from a cluster mate with the same
@@ -124,6 +156,13 @@ internal class CpuArchitectureScorer(
 		if (value.startsWith("0x")) value.removePrefix("0x").toIntOrNull(16) else value.toIntOrNull()
 
 	internal data class MidrId(val implementer: Int, val part: Int)
+
+	/**
+	 * @param score raw microarchitecture throughput estimate (never age-adjusted)
+	 * @param flagshipGenerationYear device-ship year of the newest top-frequency core design, or null
+	 * when the top cores are uncatalogued/unreadable; the caller uses it to age EXCELLENT down to HIGH
+	 */
+	internal data class CpuScore(val score: Float, val flagshipGenerationYear: Int?)
 
 	companion object {
 
@@ -215,6 +254,37 @@ internal class CpuArchitectureScorer(
 			samsung(0x002) to 2.2F, // Mongoose M3
 			samsung(0x003) to 2.6F, // Mongoose M4
 			samsung(0x004) to 2.7F, // Mongoose M5
+		)
+
+		/**
+		 * Calendar year the flagship devices carrying this core generation typically shipped (device
+		 * ship year, not the silicon vendor's announce date). Deliberately sparse: only cores that can
+		 * carry a device to EXCELLENT need a year, since the caller only age-caps EXCELLENT devices.
+		 * A new prime design added to [KNOWN_CORE_WEIGHTS] should get an entry here too; until it does,
+		 * an uncatalogued prime yields no year and is treated as current - so a just-launched flagship
+		 * is never aged. That fail-safe direction is the invariant: a MIDR (implementer, part) may be
+		 * listed only if it uniquely identifies one generation.
+		 *
+		 * ARM assigns a fresh part per core design (X2 0xd48 -> X3 0xd4e -> X4 0xd82), as does Qualcomm
+		 * for its Kryo parts, so each maps to exactly one generation. Qualcomm's Oryon is deliberately
+		 * NOT listed: every Oryon generation (Snapdragon X Elite, 8 Elite and successors) reports the
+		 * same part 0x001, told apart only by the MIDR variant field, which [parseMidrIds] does not read.
+		 * Mapping 0x001 to any single year would wrongly demote a future Oryon flagship, so Oryon
+		 * devices fall through to no-year and stay EXCELLENT (aged only via the Media-Performance-Class
+		 * path, when they declare one).
+		 */
+		private val KNOWN_CORE_GENERATION_YEARS: Map<MidrId, Int> = mapOf(
+			arm(0xd48) to 2022, // Cortex-X2   (Snapdragon 8 Gen 1 / Tensor G2)
+			arm(0xd47) to 2022, // Cortex-A710 (same generation)
+			arm(0xd4e) to 2023, // Cortex-X3   (Snapdragon 8 Gen 2 / Tensor G3 - Galaxy S23)
+			arm(0xd4d) to 2023, // Cortex-A715 (same generation)
+			arm(0xd82) to 2024, // Cortex-X4   (Snapdragon 8 Gen 3 / Tensor G4 - Galaxy S24)
+			arm(0xd81) to 2024, // Cortex-A720 (same generation)
+			arm(0xd85) to 2025, // Cortex-X925 (Dimensity 9400)
+			arm(0xd87) to 2025, // Cortex-A725 (same generation)
+			arm(0xd8b) to 2026, // C1-Pro
+			arm(0xd90) to 2026, // C1-Premium
+			arm(0xd8c) to 2026, // C1-Ultra
 		)
 	}
 }

--- a/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
+++ b/droid-dex/src/main/kotlin/com/blinkit/droiddex/cpu/utils/CpuArchitectureScorer.kt
@@ -67,23 +67,25 @@ internal class CpuArchitectureScorer(
 	 * The flagship generation year of the device, read from its top-frequency cores only (>= 95% of
 	 * its own max, [PRIME_ROLE_MIN_RELATIVE_FREQ]) with no count cap - so an all-big design like
 	 * Dimensity 8300 (four A715 cores tied at the top frequency) is covered, while an older efficiency
-	 * core paired with a newer prime (below 95% of it) is ignored. An uncatalogued (newer-than-table)
-	 * top core yields no year, so the caller never ages a just-launched flagship - failing safe toward
-	 * EXCELLENT rather than wrongly demoting new hardware.
+	 * core paired with a newer prime (below 95% of it) is ignored.
 	 *
-	 * A top core missing from /proc/cpuinfo (offline during the read) is resolved from a same-frequency
-	 * cluster mate, matching the scoring loop; only a solo prime that is both offline and mateless
-	 * yields no year - an accepted rare gap, consistent with this file's tolerance for partial cpuinfo.
+	 * Fails safe: if ANY top core cannot be dated - uncatalogued (newer than the table), or offline in
+	 * /proc/cpuinfo with no same-frequency cluster mate to inherit a design from - the whole device
+	 * yields no year, so a just-launched flagship is never aged by an older sibling. Otherwise the
+	 * newest of the top cores' years is returned.
 	 */
 	private fun flagshipGenerationYear(
 		freqsInKHz: LongArray, deviceMaxFreqInKHz: Long, midrIdsByCore: Map<Int, MidrId>
-	): Int? = freqsInKHz.indices
-		.filter { freqsInKHz[it] >= PRIME_ROLE_MIN_RELATIVE_FREQ * deviceMaxFreqInKHz }
-		.mapNotNull { core ->
-			(midrIdsByCore[core] ?: findClusterMateMidrId(core, freqsInKHz, midrIdsByCore))
-				?.let { KNOWN_CORE_GENERATION_YEARS[it] }
+	): Int? {
+		val topCores = freqsInKHz.indices.filter { freqsInKHz[it] >= PRIME_ROLE_MIN_RELATIVE_FREQ * deviceMaxFreqInKHz }
+		var newestYear: Int? = null
+		for (core in topCores) {
+			val midrId = midrIdsByCore[core] ?: findClusterMateMidrId(core, freqsInKHz, midrIdsByCore)
+			val year = midrId?.let { KNOWN_CORE_GENERATION_YEARS[it] } ?: return null
+			newestYear = maxOf(newestYear ?: year, year)
 		}
-		.maxOrNull()
+		return newestYear
+	}
 
 	/**
 	 * Fills frequencies of cores whose cpufreq node was unreadable from a cluster mate with the same
@@ -257,9 +259,11 @@ internal class CpuArchitectureScorer(
 		)
 
 		/**
-		 * Calendar year the flagship devices carrying this core generation typically shipped (device
-		 * ship year, not the silicon vendor's announce date). Deliberately sparse: only cores that can
-		 * carry a device to EXCELLENT need a year, since the caller only age-caps EXCELLENT devices.
+		 * Ship year of the NEWEST flagship device generation to use this core design as a prime - not the
+		 * design's debut year. A prime is often reused a generation later (Cortex-X4: 8 Gen 3 2024, then
+		 * Tensor G5 / Pixel 10 2025) and MIDR alone cannot tell the devices apart, so the entry takes the
+		 * latest reuse - keeping a reusing flagship EXCELLENT a year longer rather than demoting it early.
+		 * Deliberately sparse: only cores that can carry a device to EXCELLENT need a year.
 		 * A new prime design added to [KNOWN_CORE_WEIGHTS] should get an entry here too; until it does,
 		 * an uncatalogued prime yields no year and is treated as current - so a just-launched flagship
 		 * is never aged. That fail-safe direction is the invariant: a MIDR (implementer, part) may be
@@ -278,8 +282,8 @@ internal class CpuArchitectureScorer(
 			arm(0xd47) to 2022, // Cortex-A710 (same generation)
 			arm(0xd4e) to 2023, // Cortex-X3   (Snapdragon 8 Gen 2 / Tensor G3 - Galaxy S23)
 			arm(0xd4d) to 2023, // Cortex-A715 (same generation)
-			arm(0xd82) to 2024, // Cortex-X4   (Snapdragon 8 Gen 3 / Tensor G4 - Galaxy S24)
-			arm(0xd81) to 2024, // Cortex-A720 (same generation)
+			arm(0xd82) to 2025, // Cortex-X4   (8 Gen 3 2024, reused in Tensor G5 / Pixel 10 2025)
+			arm(0xd81) to 2024, // Cortex-A720 (Snapdragon 8 Gen 3 / Tensor G4)
 			arm(0xd85) to 2025, // Cortex-X925 (Dimensity 9400)
 			arm(0xd87) to 2025, // Cortex-A725 (same generation)
 			arm(0xd8b) to 2026, // C1-Pro

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ org.gradle.configuration-cache-problems=warn
 # Maven Publishing
 GROUP=com.eternal.kits
 POM_ARTIFACT_ID=droid-dex
-VERSION_NAME=4.0.0-beta01
+VERSION_NAME=4.0.0
 
 POM_NAME=Droid Dex
 POM_DESCRIPTION=Classification and Analysis of Android Device Performance


### PR DESCRIPTION
## What & why

`EXCELLENT` in the CPU classifier is meant to mean "a current flagship that can handle every feature." A once-flagship SoC no longer earns that assumption once it is a few years old. This ages such devices out of `EXCELLENT` down to `HIGH`.

Concretely: **Galaxy S23 (Snapdragon 8 Gen 2) now tiers as `HIGH`, not `EXCELLENT`.** The rule generalises — any device whose flagship silicon generation is `>= OLD_FLAGSHIP_MIN_AGE_YEARS` (3) calendar years old caps at `HIGH`.

## How

An **absolute age cliff** keyed on the SoC's core generation (not on raw score magnitude):

- `CpuArchitectureScorer.computeScore()` returns `CpuScore(score, flagshipGenerationYear)`. The generation year is the `CoreDesign.generationYear` of the device's top-frequency cores in `KNOWN_CORE_DESIGNS` (the single weight+year table), reusing the existing cluster-mate fallback so an offline top core is still resolved. The raw score is never modified.
- `CpuPerformanceManager.capOldFlagship()` drops the scored tier `EXCELLENT -> HIGH` when `currentYear() - generationYear >= 3`. Only `EXCELLENT` is capped, so a mid-tier chip that merely shares a core design with an old flagship (e.g. Snapdragon 7 Gen 3's A715) is untouched; a null year (undatable core) is left as-is.
- `applyPremiumGate()` reconciles the scored tier with the Media Performance Class certification, per read (never cached, since Play Services resolves the class asynchronously):
  - **uncertified** → `minLevel(scoredTier, hardwareCap)`; a datable chip has already self-aged through `capOldFlagship`, so it defers to the score.
  - **certified and current** → `hardwareCap` (the certification vouches for the SoC, not the memory).
  - **certification aged out** → a datable chip (non-null year) still trusts the score; an **undatable** one (null year, e.g. Oryon) is capped by the aged certification, since it has no scored age.
- The certification is aged by the same ship-year convention as the scored path, via `FLAGSHIP_SHIP_YEAR_BY_SDK_INT` (SDK int → device ship year — **not** the Android release year), so both paths age alike.
- The tier cache is keyed by `CACHE_SCHEMA_VERSION` (**bumped to 2**) and the clamped calendar year, and now persists the scored generation year (`KEY_SCORED_GENERATION_YEAR`) so the cached path can re-apply the gate. `currentYear()` is clamped to `[LIBRARY_BUILD_YEAR, LIBRARY_BUILD_YEAR + MAX_LIBRARY_AGE_YEARS]`, falling back to `LIBRARY_BUILD_YEAR` on a bad device clock — the least-aging plausible value, so a wrong clock never wrongly demotes.

### Why a cliff, not gradual decay

A first draft used a multiplicative score decay. Adversarial review killed it: decay against an absolute gate only demotes chips in the narrow `[56, 63.6)` band, so the **S23 "for Galaxy" bin (Cortex-X3 @ 3.36 GHz, raw ~64) stayed `EXCELLENT`**, and high-scoring chips (8 Elite ~130) could never demote at all. The cliff is both reliable and simpler.

## Validation (current year 2026)

| SoC | Prime core (generation) | Tier |
|---|---|---|
| Galaxy S23 / 8 Gen 2 (both bins) | Cortex-X3 (2023) | **HIGH** |
| Tensor G3, Dimensity 8300 | X3 / A715 (2023) | HIGH |
| Galaxy S24 / 8 Gen 3 | Cortex-X4 (dated 2025, the reuse year) | EXCELLENT |
| Dimensity 9400 | Cortex-X925 (2025) | EXCELLENT |
| 8 Elite / Galaxy S25 | Oryon | EXCELLENT (see notes) |
| Snapdragon 7 Gen 3 (raw 46) | A715, but below the EXCELLENT gate | HIGH (untouched) |

## Known / accepted

- **Oryon is excluded from scored aging.** Every Oryon generation reports the same MIDR part `0x001` (told apart only by the MIDR variant field, which the scorer does not parse), so it cannot be dated reliably. Its `CoreDesign.generationYear` is `null`, so `capOldFlagship` leaves it as-is and its aging is handled entirely by the certification path in `applyPremiumGate` — this became accurate with the `applyPremiumGate` restructure in this PR (commit 229b766). Verified against the Linux kernel `arch/arm64/include/asm/cputype.h` (`QCOM_CPU_PART_ORYON_X1 = 0x001`) and `pytorch/cpuinfo` (Oryon V1..V3 all under part `0x001`, disambiguated by variant).
- **An uncertified Oryon device never ages.** `applyPremiumGate` returns before aging when the device declares no Media Performance Class, and Oryon's scored tier is `EXCELLENT` with a null year, so an 8 Elite that ships without an MPC declaration stays `EXCELLENT` indefinitely. MPC declaration is optional and a fair number of OEMs skip it, so this is a real slice of the 8 Elite population, not a corner case. There is no clean fix without an SoC-identity signal (which the `CoreDesign` KDoc already names as the real answer); accepted as a known limitation until that signal exists.

## Testing

- `./gradlew droid-dex:assembleRelease` passes (the repo has no unit-test infrastructure; compile plus on-device log inspection is the established verification here — `logInfo` prints the score, flagship generation year and resulting tier).
- `CACHE_SCHEMA_VERSION` bumped to 2, so a device on an older cached schema re-derives its tier on the next launch.
- Adversarial review across multiple rounds; all critical findings resolved and re-verified.
